### PR TITLE
 Relaxed conditions to find items in inventory page.

### DIFF
--- a/InventoryKamera/Artifact.cs
+++ b/InventoryKamera/Artifact.cs
@@ -49,7 +49,7 @@ namespace InventoryKamera
 			Id = 0;
 		}
 
-		public Artifact(int _rarity, string _gearSlot, string _mainStat, int _level, SubStat[] _subStats, int _subStatsCount, string _setName, string _equippedCharacter = null, int _id = 0, bool _Lock = false)
+		public Artifact(string _setName, int _rarity, int _level, string _gearSlot, string _mainStat, SubStat[] _subStats, int _subStatsCount, string _equippedCharacter = null, int _id = 0, bool _Lock = false)
 		{
 			GearSlot = string.IsNullOrWhiteSpace(_gearSlot) ? "" : _gearSlot ;
 			Rarity = _rarity;
@@ -127,7 +127,7 @@ namespace InventoryKamera
 			{
 				return stat is null
 					? "NULL"
-					: stat.Contains("%") || stat.Contains("crit") || stat.Contains("bonus") ? $"{stat.Replace("%", "")} + {value}%" : $"{stat} + {value}";
+					: stat.Contains("_") ? $"{stat} + {value}%" : $"{stat} + {value}";
 			}
 		}
 

--- a/InventoryKamera/ArtifactScraper.cs
+++ b/InventoryKamera/ArtifactScraper.cs
@@ -595,24 +595,25 @@ namespace InventoryKamera
 
 					if (line.Contains("+"))
 					{
-						SubStat stat = new SubStat();
+						SubStat substat = new SubStat();
 						string[] split = line.Split('+');
 
 						string name = line.Contains("%") ? split[0] + "%" : split[0];
 
-						stat.stat = Scraper.FindClosestStat(name) ?? "";
+						substat.stat = Scraper.FindClosestStat(name) ?? "";
 
-						string value = split[1].Replace("%", string.Empty).Replace(",", ".");
-						if (!decimal.TryParse(value, out stat.value))
+						// Remove any non digits.
+						string value = Regex.Replace(split[1], @"[^0-9]", string.Empty);
+
+						if (!decimal.TryParse(value, out substat.value))
 						{
-							stat.value = -1;
+							substat.value = -1;
 						}
 
-						// Sometimes the decimal is missed by the scanner for stat% boosts.
-						// 46.6% is the theoretical max value for any % boost.
-						if (stat.stat.Contains("_") && stat.value > 50) stat.value /= 10; 
+						// Need to retain the decimal place for percent boosts
+						if (substat.stat.Contains("_")) substat.value /= 10; 
 
-						substats[j] = stat;
+						substats[j] = substat;
 						return null;
 					}
 					else // if (line.Contains(":")) // Sometimes Tesseract wouldn't detect a ':' making this check troublesome

--- a/InventoryKamera/CharacterScraper.cs
+++ b/InventoryKamera/CharacterScraper.cs
@@ -12,9 +12,8 @@ namespace InventoryKamera
 	{
 		private static string firstCharacterName = null;
 
-		public static List<Character> ScanCharacters()
+		public static void ScanCharacters(ref List<Character> characters)
 		{
-			List<Character> characters = new List<Character>();
 
 			// first character name is used to stop scanning characters
 			int characterCount = 0;
@@ -31,8 +30,6 @@ namespace InventoryKamera
 				Navigation.SelectNextCharacter();
 				UserInterface.ResetCharacterDisplay();
 			}
-
-			return characters;
 		}
 
 		private static bool ScanCharacter(out Character character)
@@ -260,7 +257,7 @@ namespace InventoryKamera
 					if (int.TryParse(values[0], out level) && int.TryParse(values[1], out int maxLevel))
 					{
 						maxLevel = (int)Math.Round(maxLevel / 10.0, MidpointRounding.AwayFromZero) * 10;
-						ascended = level < maxLevel;
+						ascended = 20 <= level && level < maxLevel;
 						UserInterface.SetCharacter_Level(bm, level, maxLevel);
 						n.Dispose();
 						bm.Dispose();

--- a/InventoryKamera/Form1.Designer.cs
+++ b/InventoryKamera/Form1.Designer.cs
@@ -703,6 +703,7 @@
 			// inventoryToolStripTextBox
 			// 
 			this.inventoryToolStripTextBox.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper;
+			this.inventoryToolStripTextBox.Font = new System.Drawing.Font("Segoe UI", 9F);
 			this.inventoryToolStripTextBox.MaxLength = 2;
 			this.inventoryToolStripTextBox.Name = "inventoryToolStripTextBox";
 			this.inventoryToolStripTextBox.Size = new System.Drawing.Size(90, 23);
@@ -722,6 +723,7 @@
 			// characterToolStripTextBox
 			// 
 			this.characterToolStripTextBox.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper;
+			this.characterToolStripTextBox.Font = new System.Drawing.Font("Segoe UI", 9F);
 			this.characterToolStripTextBox.MaxLength = 2;
 			this.characterToolStripTextBox.Name = "characterToolStripTextBox";
 			this.characterToolStripTextBox.Size = new System.Drawing.Size(90, 23);
@@ -815,7 +817,6 @@
 			this.Materials_CheckBox.TabIndex = 86;
 			this.Materials_CheckBox.Text = "Materials";
 			this.Materials_CheckBox.UseVisualStyleBackColor = true;
-			this.Materials_CheckBox.CheckedChanged += new System.EventHandler(this.Materials_CheckBox_CheckedChanged);
 			// 
 			// CharDevItems_CheckBox
 			// 
@@ -831,7 +832,6 @@
 			this.CharDevItems_CheckBox.TabIndex = 83;
 			this.CharDevItems_CheckBox.Text = "Char Development Items";
 			this.CharDevItems_CheckBox.UseVisualStyleBackColor = true;
-			this.CharDevItems_CheckBox.CheckedChanged += new System.EventHandler(this.CharDevItems_CheckBox_CheckedChanged);
 			// 
 			// Characters_CheckBox
 			// 
@@ -847,7 +847,6 @@
 			this.Characters_CheckBox.TabIndex = 73;
 			this.Characters_CheckBox.Text = "Characters";
 			this.Characters_CheckBox.UseVisualStyleBackColor = true;
-			this.Characters_CheckBox.CheckedChanged += new System.EventHandler(this.Characters_CheckBox_CheckedChanged);
 			// 
 			// Artifacts_Checkbox
 			// 
@@ -863,7 +862,6 @@
 			this.Artifacts_Checkbox.TabIndex = 72;
 			this.Artifacts_Checkbox.Text = "Artifacts";
 			this.Artifacts_Checkbox.UseVisualStyleBackColor = true;
-			this.Artifacts_Checkbox.CheckedChanged += new System.EventHandler(this.Artifacts_Checkbox_CheckedChanged);
 			// 
 			// Weapons_CheckBox
 			// 
@@ -879,7 +877,6 @@
 			this.Weapons_CheckBox.TabIndex = 70;
 			this.Weapons_CheckBox.Text = "Weapons";
 			this.Weapons_CheckBox.UseVisualStyleBackColor = true;
-			this.Weapons_CheckBox.CheckedChanged += new System.EventHandler(this.Weapons_CheckBox_CheckedChanged);
 			// 
 			// OutputPath_TextBox
 			// 

--- a/InventoryKamera/Form1.cs
+++ b/InventoryKamera/Form1.cs
@@ -18,14 +18,7 @@ namespace InventoryKamera
 	{
 		private static Thread mainThread;
 		private static InventoryKamera data = new InventoryKamera();
-		private static DatabaseManager databaseManager = new DatabaseManager();
 		private static string filePath = "";
-
-		private bool WeaponsChecked;
-		private bool ArtifactsChecked;
-		private bool CharactersChecked;
-		private bool MaterialsChecked;
-		private bool CharDevItemsChecked;
 
 		private int Delay;
 
@@ -90,9 +83,6 @@ namespace InventoryKamera
 
 		private void ResetUI()
 		{
-			// Reset data
-			data = new InventoryKamera();
-
 			Navigation.Reset();
 
 			// Need to invoke method from the UI's handle, not the worker thread
@@ -115,12 +105,6 @@ namespace InventoryKamera
 		private void Form1_Load(object sender, EventArgs e)
 		{
 			UpdateKeyTextBoxes();
-
-			WeaponsChecked = Weapons_CheckBox.Checked;
-			ArtifactsChecked = Artifacts_Checkbox.Checked;
-			CharactersChecked = Characters_CheckBox.Checked;
-			CharDevItemsChecked = CharDevItems_CheckBox.Checked;
-			MaterialsChecked = Materials_CheckBox.Checked;
 
 			Delay = ScannerDelay_TrackBar.Value;
 
@@ -183,6 +167,8 @@ namespace InventoryKamera
 						{
 							throw new NotImplementedException($"{Navigation.GetSize().Width}x{Navigation.GetSize().Height} is an unsupported resolution.");
 						}
+
+						data = new InventoryKamera();
 
 						// Add navigation delay
 						Navigation.SetDelay(ScannerDelayValue(Delay));
@@ -277,31 +263,6 @@ namespace InventoryKamera
 		private void SaveSettings()
 		{
 			Properties.Settings.Default.Save();
-		}
-
-		private void Weapons_CheckBox_CheckedChanged(object sender, EventArgs e)
-		{
-			WeaponsChecked = ( (CheckBox)sender ).Checked;
-		}
-
-		private void Artifacts_Checkbox_CheckedChanged(object sender, EventArgs e)
-		{
-			ArtifactsChecked = ( (CheckBox)sender ).Checked;
-		}
-
-		private void Characters_CheckBox_CheckedChanged(object sender, EventArgs e)
-		{
-			CharactersChecked = ( (CheckBox)sender ).Checked;
-		}
-
-		private void CharDevItems_CheckBox_CheckedChanged(object sender, EventArgs e)
-		{
-			CharDevItemsChecked = ( (CheckBox)sender ).Checked;
-		}
-
-		private void Materials_CheckBox_CheckedChanged(object sender, EventArgs e)
-		{
-			MaterialsChecked = ( (CheckBox)sender ).Checked;
 		}
 
 		private void ScannerDelay_TrackBar_ValueChanged(object sender, EventArgs e)

--- a/InventoryKamera/InventoryKamera.cs
+++ b/InventoryKamera/InventoryKamera.cs
@@ -74,8 +74,14 @@ namespace InventoryKamera
 				// Get Weapons
 				Navigation.InventoryScreen();
 				Navigation.SelectWeaponInventory();
-				WeaponScraper.ScanWeapons();
-				//inventory.AssignWeapons(ref equippedWeapons);
+				try
+				{
+					WeaponScraper.ScanWeapons();
+				}
+				catch (System.Exception ex)
+				{
+					UserInterface.AddError(ex.Message + "\n" + ex.StackTrace);
+				}
 				Navigation.MainMenuScreen();
 			}
 
@@ -84,8 +90,14 @@ namespace InventoryKamera
 				// Get Artifacts
 				Navigation.InventoryScreen();
 				Navigation.SelectArtifactInventory();
-				ArtifactScraper.ScanArtifacts();
-				//inventory.AssignArtifacts(ref equippedArtifacts);
+				try
+				{
+					ArtifactScraper.ScanArtifacts();
+				}
+				catch (System.Exception ex)
+				{
+					UserInterface.AddError(ex.Message + "\n" + ex.StackTrace);
+				}
 				Navigation.MainMenuScreen();
 			}
 
@@ -95,8 +107,16 @@ namespace InventoryKamera
 			{
 				// Get characters
 				Navigation.CharacterScreen();
-				Characters = new List<Character>();
-				Characters = CharacterScraper.ScanCharacters();
+				var c = new List<Character>();
+				try
+				{
+					CharacterScraper.ScanCharacters(ref c);
+				}
+				catch (System.Exception ex)
+				{
+					UserInterface.AddError(ex.Message + "\n" + ex.StackTrace);
+				}
+				Characters = c;
 				Navigation.MainMenuScreen();
 			}
 
@@ -119,7 +139,15 @@ namespace InventoryKamera
 				// Get Materials
 				Navigation.InventoryScreen();
 				Navigation.SelectCharacterDevelopmentInventory();
-				HashSet<Material> devItems = MaterialScraper.Scan_Materials(InventorySection.CharacterDevelopmentItems);
+				HashSet<Material> devItems = new HashSet<Material>();
+				try
+				{
+					MaterialScraper.Scan_Materials(InventorySection.CharacterDevelopmentItems, ref devItems);
+				}
+				catch (System.Exception ex)
+				{
+					UserInterface.AddError(ex.Message + "\n" + ex.StackTrace);
+				}
 				Inventory.AddDevItems(ref devItems);
 				Navigation.MainMenuScreen();
 			}
@@ -130,7 +158,15 @@ namespace InventoryKamera
 				// Get Materials
 				Navigation.InventoryScreen();
 				Navigation.SelectMaterialInventory();
-				HashSet<Material> materials = MaterialScraper.Scan_Materials(InventorySection.Materials);
+				HashSet<Material> materials = new HashSet<Material>();
+				try
+				{
+					MaterialScraper.Scan_Materials(InventorySection.Materials, ref materials);
+				}
+				catch (System.Exception ex)
+				{
+					UserInterface.AddError(ex.Message + "\n" + ex.StackTrace);
+				}
 				Inventory.AddMaterials(ref materials);
 				Navigation.MainMenuScreen();
 			}
@@ -171,72 +207,75 @@ namespace InventoryKamera
 								Weapon weapon = WeaponScraper.CatalogueFromBitmapsAsync(image.bm, image.id).Result;
 								UserInterface.SetGear(image.bm[4], weapon);
 
-								if (weapon.Rarity >= (int)Properties.Settings.Default.MinimumWeaponRarity) // TODO: Add options for choosing rarities
+								try
 								{
-									try
+									if (weapon.IsValid())
 									{
-										if (weapon.IsValid())
+										if (weapon.Rarity >= (int)Properties.Settings.Default.MinimumWeaponRarity)
 										{
 											UserInterface.IncrementWeaponCount();
 											Inventory.Add(weapon);
 											if (!string.IsNullOrWhiteSpace(weapon.EquippedCharacter))
 												equippedWeapons.Add(weapon);
 										}
-										else throw new System.Exception();
-									}
-									catch (System.Exception)
-									{
-										UserInterface.AddError($"Unable to validate information for weapon ID#{weapon.Id}");
-										// Save card in directory to see what an issue might be\\
-										string error = "";
-										if (!weapon.HasValidWeaponName()) error += "Invalid weapon name\n";
-										if (!weapon.HasValidLevel()) error += "Invalid weapon level\n";
-										if (!weapon.HasValidEquippedCharacter()) error += "Inavlid equipped character\n";
-										if (!weapon.HasValidRefinementLevel()) error += "Invalid refinement level\n";
-										UserInterface.AddError(error + weapon.ToString());
-										image.bm[4].Save($"./logging/weapons/weapon{weapon.Id}.png");
-									}
-								}
-							}
-						}
-						else if (image.type == "artifact")
-						{
-							UserInterface.SetGearPictureBox(image.bm[7]);
-							// Scan as artifact
-							Artifact artifact = ArtifactScraper.CatalogueFromBitmapsAsync(image.bm, image.id).Result;
-							UserInterface.SetGear(image.bm[7], artifact);
-
-							if (artifact.Rarity >= (int)Properties.Settings.Default.MinimumArtifactRarity) // TODO: Add options for choosing rarities
-							{
-								try
-								{
-									if (artifact.IsValid())
-									{
-										UserInterface.IncrementArtifactCount();
-
-										Inventory.Add(artifact);
-
-										if (!string.IsNullOrWhiteSpace(artifact.EquippedCharacter))
-											equippedArtifacts.Add(artifact);
 									}
 									else throw new System.Exception();
 								}
 								catch (System.Exception)
 								{
-									UserInterface.AddError($"Unable to validate information for artifact ID#{artifact.Id}");
-									// Save card in directory to see what an issue might be
+									UserInterface.AddError($"Unable to validate information for weapon ID#{weapon.Id}");
 									string error = "";
-									if (!artifact.HasValidLevel()) error += "Invalid artifact level\n";
-									if (!artifact.HasValidRarity()) error += "Invalid artifact rarity\n";
-									if (!artifact.HasValidSlot()) error += "Invalid artifact slot\n";
-									if (!artifact.HasValidSetName()) error += "Invalid artifact set name\n";
-									if (!artifact.HasValidMainStat()) error += "Invalid artifact main stat\n";
-									if (!artifact.HasValidSubStats()) error += "Invalid artifact sub stats\n";
-									if (!artifact.HasValidEquippedCharacter()) error += "Invalid equipped character\n";
-									UserInterface.AddError(error + artifact.ToString());
-									image.bm[7].Save($"./logging/artifacts/artifact{artifact.Id}.png");
+									if (!weapon.HasValidRarity()) error += "Invalid weapon rarity\n";
+									if (!weapon.HasValidWeaponName()) error += "Invalid weapon name\n";
+									if (!weapon.HasValidLevel()) error += "Invalid weapon level\n";
+									if (!weapon.HasValidEquippedCharacter()) error += "Inavlid equipped character\n";
+									if (!weapon.HasValidRefinementLevel()) error += "Invalid refinement level\n";
+									UserInterface.AddError(error + weapon.ToString());
+
+									// Save card in directory to see what an issue might be
+									image.bm[4].Save($"./logging/weapons/weapon{weapon.Id}.png");
 								}
+								
+
 							}
+						}
+						else if (image.type == "artifact")
+						{
+							UserInterface.SetGearPictureBox(image.bm[6]);
+							// Scan as artifact
+							Artifact artifact = ArtifactScraper.CatalogueFromBitmapsAsync(image.bm, image.id).Result;
+							UserInterface.SetGear(image.bm[6], artifact);
+							try
+							{
+								if (artifact.IsValid())
+								{
+									if (artifact.Rarity >= (int)Properties.Settings.Default.MinimumArtifactRarity)
+									{
+										UserInterface.IncrementArtifactCount();
+										Inventory.Add(artifact);
+										if (!string.IsNullOrWhiteSpace(artifact.EquippedCharacter))
+											equippedArtifacts.Add(artifact);
+									}
+								}
+								else throw new System.Exception();
+							}
+							catch (System.Exception)
+							{
+								UserInterface.AddError($"Unable to validate information for artifact ID#{artifact.Id}");
+								string error = "";
+								if (!artifact.HasValidSetName()) error += "Invalid artifact set name\n";
+								if (!artifact.HasValidRarity()) error += "Invalid artifact rarity\n";
+								if (!artifact.HasValidLevel()) error += "Invalid artifact level\n";
+								if (!artifact.HasValidSlot()) error += "Invalid artifact slot\n";
+								if (!artifact.HasValidMainStat()) error += "Invalid artifact main stat\n";
+								if (!artifact.HasValidSubStats()) error += "Invalid artifact sub stats\n";
+								if (!artifact.HasValidEquippedCharacter()) error += "Invalid equipped character\n";
+								UserInterface.AddError(error + artifact.ToString());
+
+								// Save card in directory to see what an issue might be
+								image.bm[7].Save($"./logging/artifacts/artifact{artifact.Id}.png");
+							}
+							
 						}
 						else // not supposed to happen
 						{

--- a/InventoryKamera/InventoryKamera.csproj
+++ b/InventoryKamera/InventoryKamera.csproj
@@ -133,6 +133,8 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -145,6 +147,7 @@
     <Reference Include="Tesseract, Version=4.1.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Tesseract.4.1.1\lib\net45\Tesseract.dll</HintPath>
     </Reference>
+    <Reference Include="WindowsBase" />
     <Reference Include="WindowsInput, Version=1.0.4.0, Culture=neutral, PublicKeyToken=9b287f7dc5073cad, processorArchitecture=MSIL">
       <HintPath>..\packages\InputSimulator.1.0.4.0\lib\net20\WindowsInput.dll</HintPath>
     </Reference>

--- a/InventoryKamera/MaterialScraper.cs
+++ b/InventoryKamera/MaterialScraper.cs
@@ -38,18 +38,17 @@ namespace InventoryKamera
 	public enum InventorySection
 	{
 		CharacterDevelopmentItems,
-		Food,
 		Materials,
+		Food,
 		Furnishings,
 	}
 
 	public static class MaterialScraper
 	{
-		public static HashSet<Material> Scan_Materials(InventorySection section)
+		public static void Scan_Materials(InventorySection section, ref HashSet<Material> materials)
 		{
 			int scrollCount = 0;
 
-			HashSet<Material> materials = new HashSet<Material>();
 			Material material = new Material(null, 0);
 			Material previousMaterial = new Material(null, -1);
 
@@ -60,7 +59,7 @@ namespace InventoryKamera
 			{
 				int rows, cols;
 				// Find all items on the screen
-				(rectangles, cols, rows) = GetPageOfItems(); 
+				(rectangles, cols, rows) = GetPageOfItems(section); 
 
 				// Remove last row. Sometimes the bottom of a page of items is caught which results
 				// in a faded quantity that can't be parsed. Removing slightly increases the number of pages that
@@ -142,7 +141,7 @@ namespace InventoryKamera
 
 			Navigation.Wait(500);
 
-			(rectangles, _, _) = GetPageOfItems();
+			(rectangles, _, _) = GetPageOfItems(section);
 			bool passby = true;
 			for (int i = rectangles.Count - 1; i >= 0; i--) // Click through but backwards to short-circuit after new materials
 			{
@@ -172,59 +171,9 @@ namespace InventoryKamera
 				else break;
 				Navigation.Wait(150);
 			}
-
-			return materials;
-
-			{
-				// Scan the last of the material items and stop when repeated again or until max of 28
-				//int startPostion = 1;
-				//currentColumn = 0;
-				//currentRow = 0;
-				//previousMaterial.name = null;
-				//previousRowMaterial.name = null;
-				//for (int i = startPostion; i < 5; i++)
-				//{
-				//	for (int k = 0; k < maxColumns; k++)
-				//	{
-				//		// Select Material
-				//		Navigation.SetCursorPos(Navigation.GetPosition().Left + Convert.ToInt32(materialLocation_X) + ( xOffset * ( k % maxColumns ) ), Navigation.GetPosition().Top + Convert.ToInt32(materialLocation_Y) + ( yOffset * ( i % ( maxRows + 1 ) ) ));
-				//		Navigation.SystemRandomWait(Navigation.Speed.SelectNextInventoryItem);
-				//		Navigation.Click();
-				//		Navigation.SystemRandomWait(Navigation.Speed.SelectNextInventoryItem);
-
-				//		// Scan Material Name
-				//		material.name = ScanMaterialName(section, out Bitmap nameplate);
-				//		material.count = 0;
-
-				//		// Check if new material has been found
-				//		if (material.name == previousMaterial.name || string.IsNullOrWhiteSpace(material.name))
-				//		{
-				//			break;
-				//		}
-				//		else if (Scraper.IsValidMaterial(material.name))
-				//		{
-				//			// Scan material number
-				//			material.count = ScanMaterialCountEnd(k, i - 1, out Bitmap quantity);
-				//			if (material.count > 0)
-				//			{
-				//				materials.Add(material);
-				//				previousMaterial.name = material.name;
-				//				UserInterface.ResetCharacterDisplay();
-				//				UserInterface.SetMaterial(nameplate, quantity, material.name, material.count);
-				//			}
-				//			else
-				//			{
-				//				UserInterface.AddError($"Unable to determine quantity for {material.name}");
-				//			}
-				//		}
-				//	}
-				//}
-
-				//return materials;
-			}
 		}
 
-		private static (List<Rectangle> rectangles, int cols, int rows) GetPageOfItems()
+		private static (List<Rectangle> rectangles, int cols, int rows) GetPageOfItems(InventorySection section)
 		{
 			var card = new RECT(
 				Left: 0,
@@ -233,167 +182,171 @@ namespace InventoryKamera
 				Bottom: (int)(100 / 720.0 * Navigation.GetHeight()));
 
 			// Filter for relative size of items in inventory, give or take a few pixels
-			BlobCounter blobCounter = new BlobCounter
+			using (BlobCounter blobCounter = new BlobCounter
 			{
 				FilterBlobs = true,
-				MinHeight = card.Height - (Navigation.GetAspectRatio() == new Size(16, 9) ? 0 : 10),
+				MinHeight = card.Height - ( Navigation.GetAspectRatio() == new Size(16, 9) ? 0 : 10 ),
 				MaxHeight = card.Height + 15,
-				MinWidth  = card.Width - 15,
-				MaxWidth  = card.Width + 15,
-			};
-
-			// Screenshot of inventory
-			Bitmap screenshot = Navigation.CaptureWindow();
-
-			// Copy used to overlay onto in testing
-			Bitmap output = new Bitmap(screenshot);
-
-			// Image pre-processing
-			ContrastCorrection contrast = new ContrastCorrection(90);
-			Grayscale grayscale = new Grayscale(0.2125, 0.7154, 0.0721);
-			Edges edges = new Edges();
-			Threshold threshold = new Threshold(15);
-			FillHoles holes = new FillHoles
+				MinWidth = card.Width - 15,
+				MaxWidth = card.Width + 15,
+			})
 			{
-				CoupledSizeFiltering = true,
-				MaxHoleWidth = card.Width + 10,
-				MaxHoleHeight = card.Height + 10
-			};
-			SobelEdgeDetector sobel = new SobelEdgeDetector();
 
-			screenshot = contrast.Apply(screenshot);
-			screenshot = edges.Apply(screenshot); // Quick way to find ~75% of edges
-			screenshot = grayscale.Apply(screenshot);
-			screenshot = threshold.Apply(screenshot); // Convert to black and white only based on pixel intensity
+				// Screenshot of inventory
+				Bitmap screenshot = Navigation.CaptureWindow();
 
-			screenshot = sobel.Apply(screenshot); // Find some more edges
-			screenshot = holes.Apply(screenshot); // Fill shapes
-			screenshot = sobel.Apply(screenshot); // Find edges of those shapes. A second pass removes edges within item card
+				// Copy used to overlay onto in testing
+				Bitmap output = new Bitmap(screenshot);
 
-			blobCounter.ProcessImage(screenshot);
-			// Note: Processing won't always detect all item rectangles on screen. Since the
-			// background isn't a solid color it's a bit trickier to filter out.
+				// Image pre-processing
+				ContrastCorrection contrast = new ContrastCorrection(90);
+				Grayscale grayscale = new Grayscale(0.2125, 0.7154, 0.0721);
+				Edges edges = new Edges();
+				Threshold threshold = new Threshold(15);
+				FillHoles holes = new FillHoles
+				{
+					CoupledSizeFiltering = true,
+					MaxHoleWidth = card.Width + 10,
+					MaxHoleHeight = card.Height + 10
+				};
+				SobelEdgeDetector sobel = new SobelEdgeDetector();
 
-			if (blobCounter.ObjectsCount < 1)
-			{
-				blobCounter.Dispose();
-				throw new Exception("No items detected in inventory");
-			}
+				screenshot = contrast.Apply(screenshot);
+				screenshot = edges.Apply(screenshot); // Quick way to find ~75% of edges
+				screenshot = grayscale.Apply(screenshot);
+				screenshot = threshold.Apply(screenshot); // Convert to black and white only based on pixel intensity
 
-			// Don't save overlapping blobs
-			List<Rectangle> rectangles = new List<Rectangle>();
-			List<Rectangle> blobRects = blobCounter.GetObjectsRectangles().ToList();
-			blobCounter.Dispose();
+				screenshot = sobel.Apply(screenshot); // Find some more edges
+				screenshot = holes.Apply(screenshot); // Fill shapes
+				screenshot = sobel.Apply(screenshot); // Find edges of those shapes. A second pass removes edges within item card
 
-			int sWidth = blobRects[0].Width;
-			int sHeight = blobRects[0].Height;
-			foreach (var rect in blobRects)
-			{
-				bool add = true;
+				blobCounter.ProcessImage(screenshot);
+				// Note: Processing won't always detect all item rectangles on screen. Since the
+				// background isn't a solid color it's a bit trickier to filter out.
+
+				if (blobCounter.ObjectsCount < 7)
+				{
+					output.Save($"./logging/materials/{section}Inventory.png");
+
+					screenshot.Dispose();
+					output.Dispose();
+					throw new Exception($"Insufficient items found in {section} inventory");
+				}
+
+				// Don't save overlapping blobs
+				List<Rectangle> rectangles = new List<Rectangle>();
+				List<Rectangle> blobRects = blobCounter.GetObjectsRectangles().ToList();
+
+				int sWidth = blobRects[0].Width;
+				int sHeight = blobRects[0].Height;
+				foreach (var rect in blobRects)
+				{
+					bool add = true;
+					foreach (var item in rectangles)
+					{
+						Rectangle r1 = rect;
+						Rectangle r2 = item;
+						Rectangle intersect = Rectangle.Intersect(r1, r2);
+						if (intersect.Width > r1.Width * .2)
+						{
+							add = false;
+							break;
+						}
+					}
+					if (add)
+					{
+						sWidth = Math.Min(sWidth, rect.Width);
+						sHeight = Math.Min(sHeight, rect.Height);
+						rectangles.Add(rect);
+					}
+				}
+
+				// Determine X and Y coordinates for columns and rows, respectively
+				var colCoords = new List<int>();
+				var rowCoords = new List<int>();
+
 				foreach (var item in rectangles)
 				{
-					Rectangle r1 = rect;
-					Rectangle r2 = item;
-					Rectangle intersect = Rectangle.Intersect(r1, r2);
-					if (intersect.Width > r1.Width * .2)
+					bool addX = true;
+					bool addY = true;
+					foreach (var x in colCoords)
 					{
-						add = false;
-						break;
+						var xC = item.Center().X;
+						if (x - 10 <= xC && xC <= x + 10)
+						{
+							addX = false;
+							break;
+						}
+					}
+					foreach (var y in rowCoords)
+					{
+						var yC = item.Center().Y;
+						if (y - 10 <= yC && yC <= y + 10)
+						{
+							addY = false;
+							break;
+						}
+					}
+					if (addX)
+					{
+						colCoords.Add(item.Center().X);
+					}
+					if (addY)
+					{
+						rowCoords.Add(item.Center().Y);
 					}
 				}
-				if (add)
-				{
-					sWidth = Math.Min(sWidth, rect.Width);
-					sHeight = Math.Min(sHeight, rect.Height);
-					rectangles.Add(rect);
-				}
-			}
 
-			// Determine X and Y coordinates for columns and rows, respectively
-			var colCoords = new List<int>();
-			var rowCoords = new List<int>();
-
-			foreach (var item in rectangles)
-			{
-				bool addX = true;
-				bool addY = true;
-				foreach (var x in colCoords)
+				// Clear it all because we're going to use X,Y coordinate pairings to build rectangles
+				// around. This won't be perfect but it should algorithmically put rectangles over all
+				// images on the screen. The center of each of these rectangles should be a good enough
+				// spot to click.
+				rectangles.Clear();
+				colCoords.Sort();
+				rowCoords.Sort();
+				foreach (var row in rowCoords)
 				{
-					var xC = item.Center().X;
-					if (x - 10 <= xC && xC <= x + 10)
+					foreach (var col in colCoords)
 					{
-						addX = false;
-						break;
+						int x = (int)( col - (sWidth * .5) );
+						int y = (int)( row - (sHeight * .5) );
+
+						rectangles.Add(new Rectangle(x, y, sWidth, sHeight));
 					}
 				}
-				foreach (var y in rowCoords)
+
+				// Remove some rectangles that somehow overlap each other. Don't think this happens
+				// but it doesn't hurt to double check.
+				for (int i = 0; i < rectangles.Count - 1; i++)
 				{
-					var yC = item.Center().Y;
-					if (y - 10 <= yC && yC <= y + 10)
+					for (int j = i + 1; j < rectangles.Count; j++)
 					{
-						addY = false;
-						break;
+						Rectangle r1 = rectangles[i];
+						Rectangle r2 = rectangles[j];
+						Rectangle intersect = Rectangle.Intersect(r1, r2);
+						if (intersect.Width > r1.Width * .2)
+						{
+							rectangles.RemoveAt(j);
+						}
 					}
 				}
-				if (addX)
-				{
-					colCoords.Add(item.Center().X);
-				}
-				if (addY)
-				{
-					rowCoords.Add(item.Center().Y);
-				}
+
+				// Sort by row then by column within each row
+				rectangles = rectangles.OrderBy(r => r.Top).ThenBy(r => r.Left).ToList();
+
+				Debug.WriteLine($"{colCoords.Count} columns");
+				Debug.WriteLine($"{rowCoords.Count} rows");
+				Debug.WriteLine($"{rectangles.Count} rectangles");
+
+
+				//new RectanglesMarker(rectangles, Color.Green).ApplyInPlace(output);
+				//Navigation.DisplayBitmap(output, "Rectangles");
+
+				screenshot.Dispose();
+				output.Dispose();
+
+				return (rectangles, colCoords.Count, rowCoords.Count);
 			}
-
-			// Clear it all because we're going to use X,Y coordinate pairings to build rectangles
-			// around. This won't be perfect but it should algorithmically put rectangles over all
-			// images on the screen. The center of each of these rectangles should be a good enough
-			// spot to click.
-			rectangles.Clear();
-			colCoords.Sort();
-			rowCoords.Sort();
-			foreach (var row in rowCoords)
-			{
-				foreach (var col in colCoords)
-				{
-					int x = (int)( col - (sWidth * .5) );
-					int y = (int)( row - (sHeight * .5) );
-
-					rectangles.Add(new Rectangle(x, y, sWidth, sHeight));
-				}
-			}
-
-			// Remove some rectangles that somehow overlap each other. Don't think this happens
-			// but it doesn't hurt to double check.
-			for (int i = 0; i < rectangles.Count - 1; i++)
-			{
-				for (int j = i + 1; j < rectangles.Count; j++)
-				{
-					Rectangle r1 = rectangles[i];
-					Rectangle r2 = rectangles[j];
-					Rectangle intersect = Rectangle.Intersect(r1, r2);
-					if (intersect.Width > r1.Width * .2)
-					{
-						rectangles.RemoveAt(j);
-					}
-				}
-			}
-
-			// Sort by row then by column within each row
-			rectangles = rectangles.OrderBy(r => r.Top).ThenBy(r => r.Left).ToList();
-
-			Debug.WriteLine($"{colCoords.Count} columns");
-			Debug.WriteLine($"{rowCoords.Count} rows");
-			Debug.WriteLine($"{rectangles.Count} rectangles");
-
-			
-			//new RectanglesMarker(rectangles, Color.Green).ApplyInPlace(output);
-			//Navigation.DisplayBitmap(output, "Rectangles");
-			
-			screenshot.Dispose();
-			output.Dispose();
-
-			return (rectangles, colCoords.Count, rowCoords.Count);
 		}
 
 		public static string ScanMaterialName(InventorySection section, out Bitmap nameplate)

--- a/InventoryKamera/Properties/AssemblyInfo.cs
+++ b/InventoryKamera/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Resources;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -31,5 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]
+[assembly: NeutralResourcesLanguage("en")]

--- a/InventoryKamera/Weapon.cs
+++ b/InventoryKamera/Weapon.cs
@@ -87,7 +87,12 @@ namespace InventoryKamera
 
 		public bool IsValid()
 		{
-			return HasValidWeaponName() && HasValidLevel() && HasValidEquippedCharacter() && HasValidRefinementLevel();
+			return HasValidWeaponName() && HasValidLevel() && HasValidEquippedCharacter() && HasValidRefinementLevel() && HasValidRarity();
+		}
+
+		public bool HasValidRarity()
+		{
+			return 1 <= Rarity && Rarity <= 5;
 		}
 
 		public bool HasValidLevel()

--- a/InventoryKamera/WeaponScraper.cs
+++ b/InventoryKamera/WeaponScraper.cs
@@ -90,169 +90,180 @@ namespace InventoryKamera
 
 		private static (List<Rectangle> rectangles, int cols, int rows) GetPageOfItems()
 		{
+			// Size of an item card is the same in 16:10 to 16:9. Also accounts for character icon and resolution size. 
 			var card = new RECT(
 				Left: 0,
 				Top: 0,
-				Right: (int)(80 / 1280.0 * Navigation.GetWidth()),
-				Bottom: (int)(100 / 720.0 * Navigation.GetHeight()));
+				Right: (int)(85 / 1280.0 * Navigation.GetWidth()),
+				Bottom: (int)(105 / 720.0 * Navigation.GetHeight()));
 
 			// Filter for relative size of items in inventory, give or take a few pixels
-			BlobCounter blobCounter = new BlobCounter
+			using (BlobCounter blobCounter = new BlobCounter
 			{
 				FilterBlobs = true,
-				MinHeight = card.Height - 20,
-				MaxHeight = card.Height + 20,
-				MinWidth  = card.Width - 15,
-				MaxWidth  = card.Width + 15,
-			};
-
-			// Screenshot of inventory
-			Bitmap screenshot = Navigation.CaptureWindow();
-			Bitmap output = new Bitmap(screenshot); // Copy used to overlay onto in testing
-
-			// Image pre-processing
-			ContrastCorrection contrast = new ContrastCorrection(85);
-			Grayscale grayscale = new Grayscale(0.2125, 0.7154, 0.0721);
-			Edges edges = new Edges();
-			Threshold threshold = new Threshold(15);
-			FillHoles holes = new FillHoles
+				MinHeight = card.Height - 10,
+				MaxHeight = card.Height + 10,
+				MinWidth = card.Width - 10,
+				MaxWidth = card.Width + 10,
+			})
 			{
-				CoupledSizeFiltering = true,
-				MaxHoleWidth = card.Width + 10,
-				MaxHoleHeight = card.Height + 10
-			};
-			SobelEdgeDetector sobel = new SobelEdgeDetector();
 
-			screenshot = contrast.Apply(screenshot);
-			screenshot = edges.Apply(screenshot); // Quick way to find ~75% of edges
-			screenshot = grayscale.Apply(screenshot);
-			screenshot = threshold.Apply(screenshot); // Convert to black and white only based on pixel intensity
+				// Screenshot of inventory
+				Bitmap screenshot = Navigation.CaptureWindow();
+				Bitmap output = new Bitmap(screenshot); // Copy used to overlay onto in testing
 
-			screenshot = sobel.Apply(screenshot); // Find some more edges
-			screenshot = holes.Apply(screenshot); // Fill shapes
-			screenshot = sobel.Apply(screenshot); // Find edges of those shapes. A second pass removes edges within item card
-												  //Navigation.DisplayBitmap(screenshot);
+				// Image pre-processing
+				ContrastCorrection contrast = new ContrastCorrection(85);
+				Grayscale grayscale = new Grayscale(0.2125, 0.7154, 0.0721);
+				Edges edges = new Edges();
+				Threshold threshold = new Threshold(15);
+				FillHoles holes = new FillHoles
+				{
+					CoupledSizeFiltering = true,
+					MaxHoleWidth = card.Width + 10,
+					MaxHoleHeight = card.Height + 10
+				};
+				SobelEdgeDetector sobel = new SobelEdgeDetector();
 
-			blobCounter.ProcessImage(screenshot);
-			// Note: Processing won't always detect all item rectangles on screen. Since the
-			// background isn't a solid color it's a bit trickier to filter out.
+				screenshot = contrast.Apply(screenshot);
+				screenshot = edges.Apply(screenshot); // Quick way to find ~75% of edges
+				screenshot = grayscale.Apply(screenshot);
+				screenshot = threshold.Apply(screenshot); // Convert to black and white only based on pixel intensity
 
-			if (blobCounter.ObjectsCount < 1)
-			{
-				blobCounter.Dispose();
-				throw new Exception("No items detected in inventory");
-			}
+				screenshot = sobel.Apply(screenshot); // Find some more edges
+				screenshot = holes.Apply(screenshot); // Fill shapes
+				screenshot = sobel.Apply(screenshot); // Find edges of those shapes. A second pass removes edges within item card
+													  //Navigation.DisplayBitmap(screenshot);
 
-			// Don't save overlapping blobs
-			List<Rectangle> rectangles = new List<Rectangle>();
-			List<Rectangle> blobRects = blobCounter.GetObjectsRectangles().ToList();
-			blobCounter.Dispose();
+				blobCounter.ProcessImage(screenshot);
+				// Note: Processing won't always detect all item rectangles on screen. Since the
+				// background isn't a solid color it's a bit trickier to filter out.
 
-			int sWidth = blobRects[0].Width;
-			int sHeight = blobRects[0].Height;
-			foreach (var rect in blobRects)
-			{
-				bool add = true;
+				if (blobCounter.ObjectsCount < 7)
+				{
+					output.Save("./logging/weapons/WeaponInventory.png");
+
+					screenshot.Dispose();
+					output.Dispose();
+					throw new Exception("Insufficient items found in weapon inventory");
+				}
+
+				// Don't save overlapping blobs
+				List<Rectangle> rectangles = new List<Rectangle>();
+				List<Rectangle> blobRects = blobCounter.GetObjectsRectangles().ToList();
+
+				int sWidth = blobRects[0].Width;
+				int sHeight = blobRects[0].Height;
+				foreach (var rect in blobRects)
+				{
+					bool add = true;
+					foreach (var item in rectangles)
+					{
+						Rectangle r1 = rect;
+						Rectangle r2 = item;
+						Rectangle intersect = Rectangle.Intersect(r1, r2);
+						if (intersect.Width > r1.Width * .2)
+						{
+							add = false;
+							break;
+						}
+					}
+					if (add)
+					{
+						sWidth = Math.Min(sWidth, rect.Width);
+						sHeight = Math.Min(sHeight, rect.Height);
+						rectangles.Add(rect);
+					}
+				}
+
+				// Items originally detected
+				// new RectanglesMarker(rectangles, Color.Red).ApplyInPlace(output);
+
+				// Determine X and Y coordinates for columns and rows, respectively
+				var colCoords = new List<int>();
+				var rowCoords = new List<int>();
+
 				foreach (var item in rectangles)
 				{
-					Rectangle r1 = rect;
-					Rectangle r2 = item;
-					Rectangle intersect = Rectangle.Intersect(r1, r2);
-					if (intersect.Width > r1.Width * .2)
+					bool addX = true;
+					bool addY = true;
+					foreach (var x in colCoords)
 					{
-						add = false;
-						break;
+						var xC = item.Center().X;
+						if (x - 10 <= xC && xC <= x + 10)
+						{
+							addX = false;
+							break;
+						}
+					}
+					foreach (var y in rowCoords)
+					{
+						var yC = item.Center().Y;
+						if (y - 10 <= yC && yC <= y + 10)
+						{
+							addY = false;
+							break;
+						}
+					}
+					if (addX)
+					{
+						colCoords.Add(item.Center().X);
+					}
+					if (addY)
+					{
+						rowCoords.Add(item.Center().Y);
 					}
 				}
-				if (add)
-				{
-					sWidth = Math.Min(sWidth, rect.Width);
-					sHeight = Math.Min(sHeight, rect.Height);
-					rectangles.Add(rect);
-				}
-			}
 
-			// Determine X and Y coordinates for columns and rows, respectively
-			var colCoords = new List<int>();
-			var rowCoords = new List<int>();
-
-			foreach (var item in rectangles)
-			{
-				bool addX = true;
-				bool addY = true;
-				foreach (var x in colCoords)
+				// Clear it all because we're going to use X,Y coordinate pairings to build rectangles
+				// around. This won't be perfect but it should algorithmically put rectangles over all
+				// images on the screen. The center of each of these rectangles should be a good enough
+				// spot to click.
+				rectangles.Clear();
+				colCoords.Sort();
+				rowCoords.Sort();
+				foreach (var row in rowCoords)
 				{
-					var xC = item.Center().X;
-					if (x - 10 <= xC && xC <= x + 10)
+					foreach (var col in colCoords)
 					{
-						addX = false;
-						break;
+						int x = (int)( col - (sWidth * .5) );
+						int y = (int)( row - (sHeight * .5) );
+
+						rectangles.Add(new Rectangle(x, y, sWidth, sHeight));
 					}
 				}
-				foreach (var y in rowCoords)
+
+				// Remove some rectangles that somehow overlap each other. Don't think this happens
+				// but it doesn't hurt to double check.
+				for (int i = 0; i < rectangles.Count - 1; i++)
 				{
-					var yC = item.Center().Y;
-					if (y - 10 <= yC && yC <= y + 10)
+					for (int j = i + 1; j < rectangles.Count; j++)
 					{
-						addY = false;
-						break;
+						Rectangle r1 = rectangles[i];
+						Rectangle r2 = rectangles[j];
+						Rectangle intersect = Rectangle.Intersect(r1, r2);
+						if (intersect.Width > r1.Width * .2)
+						{
+							rectangles.RemoveAt(j);
+						}
 					}
 				}
-				if (addX)
-				{
-					colCoords.Add(item.Center().X);
-				}
-				if (addY)
-				{
-					rowCoords.Add(item.Center().Y);
-				}
+
+				// Sort by row then by column within each row
+				rectangles = rectangles.OrderBy(r => r.Top).ThenBy(r => r.Left).ToList();
+
+				Debug.WriteLine($"{colCoords.Count} columns");
+				Debug.WriteLine($"{rowCoords.Count} rows");
+				Debug.WriteLine($"{rectangles.Count} rectangles");
+
+				// Generated rectangles
+				//new RectanglesMarker(rectangles, Color.Green).ApplyInPlace(output);
+				//Navigation.DisplayBitmap(output, "Rectangles");
+
+				screenshot.Dispose();
+				output.Dispose();
+				return (rectangles, colCoords.Count, rowCoords.Count);
 			}
-
-			// Clear it all because we're going to use X,Y coordinate pairings to build rectangles
-			// around. This won't be perfect but it should algorithmically put rectangles over all
-			// images on the screen. The center of each of these rectangles should be a good enough
-			// spot to click.
-			rectangles.Clear();
-			colCoords.Sort();
-			rowCoords.Sort();
-			foreach (var row in rowCoords)
-			{
-				foreach (var col in colCoords)
-				{
-					int x = (int)( col - (sWidth * .5) );
-					int y = (int)( row - (sHeight * .5) );
-
-					rectangles.Add(new Rectangle(x, y, sWidth, sHeight));
-				}
-			}
-
-			// Remove some rectangles that somehow overlap each other. Don't think this happens
-			// but it doesn't hurt to double check.
-			for (int i = 0; i < rectangles.Count - 1; i++)
-			{
-				for (int j = i + 1; j < rectangles.Count; j++)
-				{
-					Rectangle r1 = rectangles[i];
-					Rectangle r2 = rectangles[j];
-					Rectangle intersect = Rectangle.Intersect(r1, r2);
-					if (intersect.Width > r1.Width * .2)
-					{
-						rectangles.RemoveAt(j);
-					}
-				}
-			}
-
-			// Sort by row then by column within each row
-			rectangles = rectangles.OrderBy(r => r.Top).ThenBy(r => r.Left).ToList();
-
-			Debug.WriteLine($"{colCoords.Count} columns");
-			Debug.WriteLine($"{rowCoords.Count} rows");
-			Debug.WriteLine($"{rectangles.Count} rectangles");
-
-			//new RectanglesMarker(rectangles, Color.Green).ApplyInPlace(output);
-			//Navigation.DisplayBitmap(output, "Rectangles");
-
-			return (rectangles, colCoords.Count, rowCoords.Count);
 		}
 
 		public static void QueueScan(int id)
@@ -338,7 +349,8 @@ namespace InventoryKamera
 
 			try
 			{
-				if (GetRarity(name.GetPixel(5, 5)) < Properties.Settings.Default.MinimumWeaponRarity)
+				int rarity = GetRarity(name.GetPixel(5, 5));
+				if (0 < rarity && rarity < Properties.Settings.Default.MinimumWeaponRarity)
 				{
 					weaponImages.ForEach(i => i.Dispose());
 					StopScanning = true;
@@ -346,11 +358,6 @@ namespace InventoryKamera
 				}
 				else // Send images to worker queue
 					InventoryKamera.workerQueue.Enqueue(new OCRImage(weaponImages, "weapon", id));
-			}
-			catch (ArgumentException ex)
-			{
-				UserInterface.AddError($"{ex.Message} for weapon ID#{id}");
-				card.Save($"./logging/weapons/weapon{id}.png");
 			}
 			catch (Exception ex)
 			{
@@ -420,7 +427,7 @@ namespace InventoryKamera
 			else if (Scraper.CompareColors(threeStar, rarityColor)) return 3;
 			else if (Scraper.CompareColors(twoStar, rarityColor)) return 2;
 			else if (Scraper.CompareColors(oneStar, rarityColor)) return 1;
-			else throw new ArgumentException("Unable to determine weapon rarity");
+			else return 0; //throw new ArgumentException("Unable to determine weapon rarity");
 		}
 
 		public static bool IsEnhancementOre(Bitmap nameBitmap)
@@ -497,7 +504,7 @@ namespace InventoryKamera
 			return text1;
 		}
 
-		public static int ScanLevel(Bitmap bm, ref bool ascension)
+		public static int ScanLevel(Bitmap bm, ref bool ascended)
 		{
 			Bitmap n = Scraper.ConvertToGrayscale(bm);
 			Scraper.SetInvert(ref n);
@@ -514,7 +521,8 @@ namespace InventoryKamera
 				{
 					if (int.TryParse(temp[0], out int level) && int.TryParse(temp[1], out int maxLevel))
 					{
-						ascension = level < maxLevel;
+						maxLevel = (int)Math.Round(maxLevel / 10.0, MidpointRounding.AwayFromZero) * 10;
+						ascended = 20 <= level && level < maxLevel;
 						return level;
 					}
 					else


### PR DESCRIPTION
Inventory searching now saves output if it cannot find sufficient number of items in inventory.
Item rarity filtering done after item validation.
Scanner continues on to next section if one section throws an error or crashes. Anything scanned and already saved in that section is preserved.
Possible fix for languages that use different numeric styles for period and comma placement.