### PR TITLE
now tryParse always uses en-US CultureInfo

### DIFF
--- a/InventoryKamera/ArtifactScraper.cs
+++ b/InventoryKamera/ArtifactScraper.cs
@@ -600,7 +600,8 @@ namespace InventoryKamera
 						stat.stat = Scraper.FindClosestStat(name) ?? "";
 
 						string value = split[1].Replace("%", string.Empty);
-						if (!decimal.TryParse(value, out stat.value))
+						var cultureInfo = new CultureInfo("en-US");
+						if (!decimal.TryParse(value, System.Globalization.NumberStyles.Number, cultureInfo, out stat.value))
 						{
 							stat.value = -1;
 						}


### PR DESCRIPTION
TryParse did fail to correctly parse "14.0" as 14.0m if the systems was using non en-US Culture Info per default (de-de for example).

Inventory_Kamera is only supported for the english language of Genshin right now. So enforcing en-US culture Info fixes this problem.