### PR TITLE
Added Mora Scanning, Privary Tweak, and Relaxed Text Matching

### DIFF
--- a/InventoryKamera/Form1.cs
+++ b/InventoryKamera/Form1.cs
@@ -18,7 +18,6 @@ namespace InventoryKamera
 	{
 		private static Thread mainThread;
 		private static InventoryKamera data = new InventoryKamera();
-		private static string filePath = "";
 
 		private int Delay;
 
@@ -109,6 +108,10 @@ namespace InventoryKamera
 			Delay = ScannerDelay_TrackBar.Value;
 
 			ProgramStatus_Label.Text = "";
+			if (string.IsNullOrWhiteSpace(OutputPath_TextBox.Text))
+			{
+				OutputPath_TextBox.Text = Directory.GetCurrentDirectory() + @"\GenshinData";
+			}
 		}
 
 		private void UpdateKeyTextBoxes()
@@ -243,14 +246,13 @@ namespace InventoryKamera
 			// A nicer file browser
 			CommonOpenFileDialog d = new CommonOpenFileDialog
 			{
-				InitialDirectory = filePath,
+				InitialDirectory = Directory.GetCurrentDirectory(),
 				IsFolderPicker = true
 			};
 
 			if (d.ShowDialog() == CommonFileDialogResult.Ok)
 			{
 				OutputPath_TextBox.Text = d.FileName;
-				filePath = d.FileName;
 			}
 		}
 

--- a/InventoryKamera/InventoryKamera.cs
+++ b/InventoryKamera/InventoryKamera.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using Newtonsoft.Json;
 
@@ -142,13 +143,12 @@ namespace InventoryKamera
 				HashSet<Material> devItems = new HashSet<Material>();
 				try
 				{
-					MaterialScraper.Scan_Materials(InventorySection.CharacterDevelopmentItems, ref devItems);
+					MaterialScraper.Scan_Materials(InventorySection.CharacterDevelopmentItems, ref Materials);
 				}
 				catch (System.Exception ex)
 				{
 					UserInterface.AddError(ex.Message + "\n" + ex.StackTrace);
 				}
-				Inventory.AddDevItems(ref devItems);
 				Navigation.MainMenuScreen();
 			}
 
@@ -161,15 +161,16 @@ namespace InventoryKamera
 				HashSet<Material> materials = new HashSet<Material>();
 				try
 				{
-					MaterialScraper.Scan_Materials(InventorySection.Materials, ref materials);
+					MaterialScraper.Scan_Materials(InventorySection.Materials, ref Materials);
 				}
 				catch (System.Exception ex)
 				{
 					UserInterface.AddError(ex.Message + "\n" + ex.StackTrace);
 				}
-				Inventory.AddMaterials(ref materials);
 				Navigation.MainMenuScreen();
 			}
+
+			Inventory.AddMaterials(ref Materials);
 			
 		}
 
@@ -199,13 +200,13 @@ namespace InventoryKamera
 					{
 						if (image.type == "weapon")
 						{
-							if (!WeaponScraper.IsEnhancementOre(image.bm[0]))
+							if (!WeaponScraper.IsEnhancementOre(image.bm.First()))
 							{
-								UserInterface.SetGearPictureBox(image.bm[4]);
+								UserInterface.SetGearPictureBox(image.bm.Last());
 
 								// Scan as weapon
 								Weapon weapon = WeaponScraper.CatalogueFromBitmapsAsync(image.bm, image.id).Result;
-								UserInterface.SetGear(image.bm[4], weapon);
+								UserInterface.SetGear(image.bm.Last(), weapon);
 
 								try
 								{
@@ -233,18 +234,16 @@ namespace InventoryKamera
 									UserInterface.AddError(error + weapon.ToString());
 
 									// Save card in directory to see what an issue might be
-									image.bm[4].Save($"./logging/weapons/weapon{weapon.Id}.png");
+									image.bm.Last().Save($"./logging/weapons/weapon{weapon.Id}.png");
 								}
-								
-
 							}
 						}
 						else if (image.type == "artifact")
 						{
-							UserInterface.SetGearPictureBox(image.bm[6]);
+							UserInterface.SetGearPictureBox(image.bm.Last());
 							// Scan as artifact
 							Artifact artifact = ArtifactScraper.CatalogueFromBitmapsAsync(image.bm, image.id).Result;
-							UserInterface.SetGear(image.bm[6], artifact);
+							UserInterface.SetGear(image.bm.Last(), artifact);
 							try
 							{
 								if (artifact.IsValid())
@@ -273,7 +272,7 @@ namespace InventoryKamera
 								UserInterface.AddError(error + artifact.ToString());
 
 								// Save card in directory to see what an issue might be
-								image.bm[7].Save($"./logging/artifacts/artifact{artifact.Id}.png");
+								image.bm.Last().Save($"./logging/artifacts/artifact{artifact.Id}.png");
 							}
 							
 						}

--- a/InventoryKamera/MaterialScraper.cs
+++ b/InventoryKamera/MaterialScraper.cs
@@ -47,6 +47,11 @@ namespace InventoryKamera
 	{
 		public static void Scan_Materials(InventorySection section, ref HashSet<Material> materials)
 		{
+			if (!materials.Contains(new Material("Mora", 0)))
+			{
+				materials.Add(new Material("Mora", ScanMora()));
+			}
+
 			int scrollCount = 0;
 
 			Material material = new Material(null, 0);
@@ -170,6 +175,39 @@ namespace InventoryKamera
 				}
 				else break;
 				Navigation.Wait(150);
+			}
+		}
+
+		private static int ScanMora()
+		{
+
+			var region = new Rectangle(
+				x: (int)(261 / 1280.0 * Navigation.GetWidth()),
+				y: (int)(668 / 720.0 * Navigation.GetHeight()),
+				width: (int)(120 / 1280.0 * Navigation.GetWidth()),
+				height: (int)(24 / 720.0 * Navigation.GetHeight()));
+
+			if (Navigation.GetAspectRatio() == new Size(8,5))
+			{
+				region.Y = (int)( 748 / 800.0 * Navigation.GetHeight());
+			}
+
+			using (var bm = Navigation.CaptureRegion(region))
+			{
+				var mora = Regex.Replace(Scraper.AnalyzeText(bm), @"[^0-9]", string.Empty);
+
+				if (int.TryParse(mora, out int count))
+				{
+					UserInterface.ResetCharacterDisplay();
+					UserInterface.SetMora(bm, count);
+				}
+				else
+				{
+					UserInterface.SetNavigation_Image(bm);
+					UserInterface.AddError("Unable to parse mora count");
+					bm.Save("./logging/materials/mora.png");
+				}
+				return count;
 			}
 		}
 

--- a/InventoryKamera/Navigation.cs
+++ b/InventoryKamera/Navigation.cs
@@ -51,6 +51,13 @@ namespace InventoryKamera
 			using (Graphics gfxBmp = Graphics.FromImage(bmp))
 			{
 				gfxBmp.CopyFromScreen(position.Left, position.Top, 0, 0, bmp.Size);
+
+				var uidRegion = new RECT(
+					Left: (int)( 1070 / 1280.0 * bmp.Width ),
+					Top: (int)( 695 / 720.0 * bmp.Height ),
+					Right: bmp.Width,
+					Bottom: bmp.Height);
+				gfxBmp.FillRectangle(new SolidBrush(Color.Black), uidRegion);
 			}
 			return bmp;
 		}

--- a/InventoryKamera/Scraper.cs
+++ b/InventoryKamera/Scraper.cs
@@ -362,7 +362,7 @@ namespace InventoryKamera
 
 			HashSet<string> keys = new HashSet<string>(targets.Keys);
 
-			if (source.Length > 5 && keys.Where(key => key.Contains(source)).Count() == 1) return targets[keys.First(key => key.Contains(source))];
+			if (keys.Where(key => key.Contains(source)).Count() == 1) return targets[keys.First(key => key.Contains(source))];
 
 			source = FindClosestInList(source, keys);
 

--- a/InventoryKamera/UserInterface.cs
+++ b/InventoryKamera/UserInterface.cs
@@ -180,6 +180,12 @@ namespace InventoryKamera
 			UpdateElements(quantity, $"Count: {count}", cLevel_PictureBox, character_TextBox);
 		}
 
+		public static void SetMora(Bitmap mora, int count)
+		{
+			UpdateElements(mora, $"Mora: {count}", navigation_PictureBox, character_TextBox);
+		}
+
+
 		public static void SetCharacter_Talent(Bitmap bm, string text, int i)
 		{
 			if (i > -1 && i < 3)

--- a/InventoryKamera/WeaponScraper.cs
+++ b/InventoryKamera/WeaponScraper.cs
@@ -28,6 +28,12 @@ namespace InventoryKamera
 			int offset = 0;
 			UserInterface.SetWeapon_Max(weaponCount);
 
+			// Enhancement ores being in the same inventory as weapons
+			// can throw off scrolling through the inventory in certain circumstances
+			// This fix is fine for now since most people don't scan below 3 stars
+			// TODO: Rewrite this method to allow for scanning enhancement ore quantities
+			weaponCount += 3;
+
 			// Determine Delay if delay has not been found before
 			// Scraper.FindDelay(rectangles);
 


### PR DESCRIPTION
- Relaxed partial text matching requirements. This aims to fix mostly artifact set name matching as the green set name text was sometimes not fully scanned. This would sometimes match to a wrong set name since the matching only uses minimum number of edits as a matching metric.
- Added default output directory
- Added black box over UID for screenshots that might be taken of the full game window as a privacy change. These aren't actually collected anywhere but it saves users the work of hiding their UID if they have to upload a screenshot that was saved as part of logging.