### PR TITLE
Bug Fixes and Features

### DIFF
--- a/InventoryKamera/Program.cs
+++ b/InventoryKamera/Program.cs
@@ -51,7 +51,10 @@ namespace InventoryKamera
 				ArchiveFileKind = NLog.Targets.FilePathKind.Relative
 			};
 
-			var logConsole = new NLog.Targets.ConsoleTarget("logconsole");
+			var logConsole = new NLog.Targets.ConsoleTarget("logconsole")
+			{
+				Layout = "${date:format=yyyy-MM-dd HH\\:mm\\:ss.fff}|${level:uppercase=true}|${logger:shortName=True}|${message:withexception=true}",
+			};
 
 			config.AddRule(LogLevel.Debug, LogLevel.Fatal, logConsole);
 			config.AddRule(LogLevel.Debug, LogLevel.Fatal, logFile);

--- a/InventoryKamera/Program.cs
+++ b/InventoryKamera/Program.cs
@@ -37,6 +37,20 @@ namespace InventoryKamera
         {
             var config = new NLog.Config.LoggingConfiguration();
 
+			var debugFile = new NLog.Targets.FileTarget("logfile")
+			{
+				Layout = "${date:format=yyyy-MM-dd HH\\:mm\\:ss.fff}|${level:uppercase=true}|${logger:shortName=True}|${message:withexception=true}",
+				FileName = "./logging/InventoryKamera.debug.log",
+				ArchiveFileName = "logging/archives/InventoryKamera.{####}.debug.log",
+				ArchiveNumbering = NLog.Targets.ArchiveNumberingMode.Date,
+				ArchiveDateFormat = "yyyyMMddHHmmss",
+				MaxArchiveFiles = 4,
+				ConcurrentWrites = true,
+				KeepFileOpen = true,
+				ArchiveOldFileOnStartup = true,
+				ArchiveFileKind = NLog.Targets.FilePathKind.Relative
+			};
+
 			var logFile = new NLog.Targets.FileTarget("logfile")
 			{
 				Layout = "${date:format=yyyy-MM-dd HH\\:mm\\:ss.fff}|${level:uppercase=true}|${logger:shortName=True}|${message:withexception=true}",
@@ -57,7 +71,8 @@ namespace InventoryKamera
 			};
 
 			config.AddRule(LogLevel.Debug, LogLevel.Fatal, logConsole);
-			config.AddRule(LogLevel.Debug, LogLevel.Fatal, logFile);
+			config.AddRule(LogLevel.Debug, LogLevel.Fatal, debugFile);
+			config.AddRule(LogLevel.Info, LogLevel.Fatal, logFile);
 
             LogManager.Configuration = config;
         }

--- a/InventoryKamera/Properties/AssemblyInfo.cs
+++ b/InventoryKamera/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.5.0")]
-[assembly: AssemblyFileVersion("1.2.5.0")]
+[assembly: AssemblyVersion("1.2.6.0")]
+[assembly: AssemblyFileVersion("1.2.6.0")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/InventoryKamera/data/InventoryKamera.cs
+++ b/InventoryKamera/data/InventoryKamera.cs
@@ -241,6 +241,8 @@ namespace InventoryKamera
 
 							string weaponPath = $"./logging/weapons/weapon{weapon.Id}/";
 
+							if (Properties.Settings.Default.LogScreenshots) Directory.CreateDirectory(weaponPath);
+
 							if (weapon.IsValid())
 							{
 								if (weapon.Rarity <= (int)Properties.Settings.Default.MinimumWeaponRarity &&
@@ -260,28 +262,13 @@ namespace InventoryKamera
 							{
 								UserInterface.AddError($"Unable to validate information for weapon ID#{weapon.Id}");
 								string error = "";
-								if (!weapon.HasValidWeaponName())
-								{
-									error += "Invalid weapon name\n";
-								}
-								if (!weapon.HasValidRarity())
-								{
-									error += "Invalid weapon rarity\n";
-									
-								}
-								if (!weapon.HasValidLevel())
-								{
-									error += "Invalid weapon level\n";
-								}
-								if (!weapon.HasValidRefinementLevel())
-								{
-									error += "Invalid refinement level\n";
-								}
-								if (!weapon.HasValidEquippedCharacter())
-								{
-									error += "Inavlid equipped character\n";
-								}
+								if (!weapon.HasValidWeaponName()) error += "Invalid weapon name\n"; 
+								if (!weapon.HasValidRarity()) error += "Invalid weapon rarity\n";
+								if (!weapon.HasValidLevel()) error += "Invalid weapon level\n";
+								if (!weapon.HasValidRefinementLevel()) error += "Invalid refinement level\n";
+								if (!weapon.HasValidEquippedCharacter()) error += "Inavlid equipped character\n";
 								UserInterface.AddError(error + weapon.ToString());
+								Directory.CreateDirectory(weaponPath);
 								using (var writer = File.CreateText(weaponPath + "log.txt"))
 								{
 									writer.WriteLine($"Version: {Regex.Replace(Assembly.GetExecutingAssembly().GetName().Version.ToString(), @"[.0]*$", string.Empty)}");
@@ -297,8 +284,6 @@ namespace InventoryKamera
 
                             if (!weapon.IsValid() || Properties.Settings.Default.LogScreenshots)
                             {
-								Directory.CreateDirectory(weaponPath);
-
 								Directory.CreateDirectory(weaponPath + "name");
 								imageCollection.Bitmaps[0].Save(weaponPath + "name/name.png");
 								Directory.CreateDirectory(weaponPath + "rarity");
@@ -309,6 +294,7 @@ namespace InventoryKamera
 								imageCollection.Bitmaps[2].Save(weaponPath + "refinement/refinement.png");
 								Directory.CreateDirectory(weaponPath + "equipped");
 								imageCollection.Bitmaps[4].Save(weaponPath + "equipped/equipped.png");
+
 								imageCollection.Bitmaps.Last().Save(weaponPath + "card.png");
 							}
 
@@ -331,6 +317,8 @@ namespace InventoryKamera
 
 							string artifactPath = $"./logging/artifacts/artifact{artifact.Id}/";
 
+                            if (Properties.Settings.Default.LogScreenshots) Directory.CreateDirectory(artifactPath);
+
 							if (artifact.IsValid())
 							{
 								if (artifact.Rarity <= (int)Properties.Settings.Default.MinimumArtifactRarity &&
@@ -350,36 +338,15 @@ namespace InventoryKamera
 							{
 								UserInterface.AddError($"Unable to validate information for artifact ID#{artifact.Id}");
 								string error = "";
-								if (!artifact.HasValidSlot())
-								{
-									error += "Invalid artifact gear slot\n";
-								}
-								if (!artifact.HasValidSetName())
-								{
-									error += "Invalid artifact set name\n";
-								}
-								if (!artifact.HasValidRarity())
-								{
-									error += "Invalid artifact rarity\n";
-								}
-								if (!artifact.HasValidLevel())
-								{
-									error += "Invalid artifact level\n";
-								}
-								if (!artifact.HasValidMainStat())
-								{
-									error += "Invalid artifact main stat\n";
-								}
-								if (!artifact.HasValidSubStats())
-								{
-									error += "Invalid artifact sub stats\n";
-								}
-								if (!artifact.HasValidEquippedCharacter())
-								{
-									error += "Invalid equipped character\n";
-								}
+								if (!artifact.HasValidSlot()) error += "Invalid artifact gear slot\n";
+								if (!artifact.HasValidSetName()) error += "Invalid artifact set name\n";
+								if (!artifact.HasValidRarity()) error += "Invalid artifact rarity\n";
+								if (!artifact.HasValidLevel()) error += "Invalid artifact level\n";
+								if (!artifact.HasValidMainStat()) error += "Invalid artifact main stat\n";
+								if (!artifact.HasValidSubStats()) error += "Invalid artifact sub stats\n";
+								if (!artifact.HasValidEquippedCharacter()) error += "Invalid equipped character\n";
 								UserInterface.AddError(error + artifact.ToString());
-
+								Directory.CreateDirectory(artifactPath);
 								using (var writer = File.CreateText(artifactPath + "log.txt"))
 								{
 									writer.WriteLine($"Version: {Regex.Replace(Assembly.GetExecutingAssembly().GetName().Version.ToString(), @"[.0]*$", string.Empty)}");
@@ -395,8 +362,6 @@ namespace InventoryKamera
 
                             if (!artifact.IsValid() || Properties.Settings.Default.LogScreenshots)
                             {
-								Directory.CreateDirectory(artifactPath);
-
 								Directory.CreateDirectory(artifactPath + "slot");
 								imageCollection.Bitmaps[1].Save(artifactPath + "slot/slot.png");
 								Directory.CreateDirectory(artifactPath + "set");

--- a/InventoryKamera/data/InventoryKamera.cs
+++ b/InventoryKamera/data/InventoryKamera.cs
@@ -16,17 +16,22 @@ namespace InventoryKamera
 		private static NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
 		[JsonProperty]
-		public List<Character> Characters { get; private set; }
+		public List<Character> Characters;
 
 		[JsonProperty]
-		public Inventory Inventory = new Inventory();
+		public Inventory Inventory;
 
-		private static List<Artifact> equippedArtifacts;
-		private static List<Weapon> equippedWeapons;
+		private List<Artifact> equippedArtifacts;
+		private List<Weapon> equippedWeapons;
 		public static Queue<OCRImageCollection> workerQueue;
-		private static List<Thread> ImageProcessors;
-		private static volatile bool b_threadCancel = false;
-		private static int maxProcessors = 2; // TODO: Add support for more processors
+		private List<Thread> ImageProcessors;
+		private volatile bool b_threadCancel;
+		private int maxProcessors = 2; // TODO: Add support for more processors
+
+		public bool HasData
+        {
+			get { return Characters.Count > 0 || Inventory.Size > 0; }
+        }
 
 		public InventoryKamera()
 		{
@@ -36,6 +41,8 @@ namespace InventoryKamera
 			equippedWeapons = new List<Weapon>();
 			ImageProcessors = new List<Thread>();
 			workerQueue = new Queue<OCRImageCollection>();
+
+			b_threadCancel = false;
 
 			ResetLogging();
 		}
@@ -56,7 +63,7 @@ namespace InventoryKamera
 			Directory.CreateDirectory("./logging/characters");
 			Directory.CreateDirectory("./logging/materials");
 
-			Logger.Info("Logging directory created");
+			Logger.Info("Logging directory reset");
 		}
 
 		public void StopImageProcessorWorkers()
@@ -133,7 +140,7 @@ namespace InventoryKamera
 				Navigation.CharacterScreen();
 				try
 				{
-					Characters = CharacterScraper.ScanCharacters();
+					CharacterScraper.ScanCharacters(ref Characters);
 				}
 				catch (ThreadAbortException) { }
 				catch (Exception ex)

--- a/InventoryKamera/data/InventoryKamera.cs
+++ b/InventoryKamera/data/InventoryKamera.cs
@@ -26,7 +26,7 @@ namespace InventoryKamera
 		public static Queue<OCRImageCollection> workerQueue;
 		private List<Thread> ImageProcessors;
 		private volatile bool b_threadCancel;
-		private int maxProcessors = 2; // TODO: Add support for more processors
+		private readonly int NumWorkers;
 
 		public bool HasData
         {
@@ -44,7 +44,17 @@ namespace InventoryKamera
 
 			b_threadCancel = false;
 
-			ResetLogging();
+            switch (Properties.Settings.Default.ScannerDelay)
+            {
+				case 0:
+					NumWorkers = 3;
+					break;
+				default:
+					NumWorkers = 2;
+					break;
+            }
+
+            ResetLogging();
 		}
 
 		public void ResetLogging()
@@ -76,7 +86,7 @@ namespace InventoryKamera
 		public void GatherData()
 		{
 			// Initize Image Processors
-			for (int i = 0; i < maxProcessors; i++)
+			for (int i = 0; i < NumWorkers; i++)
 			{
 				Thread processor = new Thread(ImageProcessorWorker){ IsBackground = true };
 				processor.Start();

--- a/InventoryKamera/game/Character.cs
+++ b/InventoryKamera/game/Character.cs
@@ -7,8 +7,25 @@ namespace InventoryKamera
 	[Serializable]
 	public class Character
 	{
+		private string name;
+
 		[JsonProperty("key")]
-		public string Name { get; internal set; }
+		public string Name { 
+			
+			get { return name; }
+
+			internal set 
+			{
+				try
+				{
+					name = (string)Scraper.Characters[value.ToLower()]["GOOD"];
+				}
+				catch (Exception)
+				{
+					name = value;
+				}
+			} 
+		}
 
 		[JsonProperty("level")]
 		public int Level { get; internal set; }
@@ -54,12 +71,7 @@ namespace InventoryKamera
 
 		public Character(string _name, string _element, int _level, bool _ascension, int _experience, int _constellation, int[] _talents, WeaponType _weaponType) : this()
 		{
-			try
-			{
-				Name = (string)Scraper.Characters[_name.ToLower()]["GOOD"];
-			}
-			catch (Exception)
-			{ }
+			
 			Element = _element;
 			Level = _level;
 			Ascended = _ascension;

--- a/InventoryKamera/game/Character.cs
+++ b/InventoryKamera/game/Character.cs
@@ -8,38 +8,38 @@ namespace InventoryKamera
 	public class Character
 	{
 		[JsonProperty("key")]
-		public string Name { get; private set; }
+		public string Name { get; internal set; }
 
 		[JsonProperty("level")]
-		public int Level { get; private set; }
+		public int Level { get; internal set; }
 
 		[JsonProperty("constellation")]
-		public int Constellation { get; private set; }
+		public int Constellation { get; internal set; }
 
 		[JsonProperty("ascension")]
 		public int Ascension
-		{ get { return AscensionLevel(); } private set { } }
+		{ get { return AscensionLevel(); } internal set { } }
 
 		[JsonProperty("talent")]
-		public Dictionary<string, int> Talents { get; private set; }
+		public Dictionary<string, int> Talents { get; internal set; }
 
 		[JsonIgnore]
-		public string Element { get; private set; }
+		public string Element { get; internal set; }
 
 		[JsonIgnore]
-		public bool Ascended { get; private set; }
+		public bool Ascended { get; internal set; }
 
 		[JsonIgnore]
-		public int Experience { get; private set; }
+		public int Experience { get; internal set; }
 
 		[JsonIgnore]
-		public Weapon Weapon { get; private set; }
+		public Weapon Weapon { get; internal set; }
 
 		[JsonIgnore]
-		public Dictionary<string, Artifact> Artifacts { get; private set; }
+		public Dictionary<string, Artifact> Artifacts { get; internal set; }
 
 		[JsonIgnore]
-		public WeaponType WeaponType { get; private set; }
+		public WeaponType WeaponType { get; internal set; }
 
 		public Character()
 		{

--- a/InventoryKamera/game/Navigation.cs
+++ b/InventoryKamera/game/Navigation.cs
@@ -21,7 +21,7 @@ namespace InventoryKamera
 		internal static RECT WindowPosition;
 		internal static Size AspectRatio;
 
-		private static int delay = 0;
+		private static double delay = 1;
 
 		public static VirtualKeyCode escapeKey = VirtualKeyCode.ESCAPE;
 		public static VirtualKeyCode characterKey = VirtualKeyCode.VK_C;
@@ -149,7 +149,7 @@ namespace InventoryKamera
 			int buttonY = (int)(35  / 720.0 * GetHeight());
 			SetCursor(buttonX, buttonY);
 			Click();
-			SystemRandomWait(Speed.UI);
+			SystemWait(Speed.UI);
 		}
 
 		public static void SelectArtifactInventory()
@@ -158,7 +158,7 @@ namespace InventoryKamera
 			int buttonY = (int)(31 / 720.0 * GetHeight());
 			SetCursor(buttonX, buttonY);
 			Click();
-			SystemRandomWait(Speed.UI);
+			SystemWait(Speed.UI);
 		}
 
 		public static void SelectCharacterDevelopmentInventory()
@@ -167,7 +167,7 @@ namespace InventoryKamera
 			int buttonY = (int)(40  / 720.0 * GetHeight());
 			SetCursor(buttonX, buttonY);
 			Click();
-			SystemRandomWait(Speed.UI);
+			SystemWait(Speed.UI);
 		}
 
 		public static void SelectMaterialInventory()
@@ -176,7 +176,7 @@ namespace InventoryKamera
 			int buttonY = (int)(30  / 720.0 * GetHeight());
 			SetCursor(buttonX, buttonY);
 			Click();
-			SystemRandomWait(Speed.UI);
+			SystemWait(Speed.UI);
 		}
 
 		public static void SelectCharacterAttributes()
@@ -191,7 +191,7 @@ namespace InventoryKamera
 
 			SetCursor(xOffset, yOffset);
 			Click();
-			SystemRandomWait(Speed.CharacterUI);
+			SystemWait(Speed.CharacterUI);
 		}
 
 		public static void SelectCharacterConstellation()
@@ -206,7 +206,7 @@ namespace InventoryKamera
 
 			SetCursor(xOffset, yOffset);
 			Click();
-			SystemRandomWait(Speed.CharacterUI);
+			SystemWait(Speed.CharacterUI);
 		}
 
 		public static void SelectCharacterTalents()
@@ -221,7 +221,7 @@ namespace InventoryKamera
 
 			SetCursor(xOffset, yOffset);
 			Click();
-			SystemRandomWait(Speed.CharacterUI);
+			SystemWait(Speed.CharacterUI);
 		}
 
 		public static void SelectNextCharacter()
@@ -236,31 +236,31 @@ namespace InventoryKamera
 
 			SetCursor(xOffset, yOffset);
 			Click();
-			SystemRandomWait(Speed.SelectNextCharacter);
+			SystemWait(Speed.SelectNextCharacter);
 		}
 
 		public static void CharacterScreen()
 		{
 			sim.Keyboard.KeyPress(escapeKey);
-			SystemRandomWait(Speed.UI);
+			SystemWait(Speed.UI);
 			sim.Keyboard.KeyPress(characterKey);
-			SystemRandomWait(Speed.UI);
+			SystemWait(Speed.UI);
 		}
 
 		public static void InventoryScreen()
 		{
 			sim.Keyboard.KeyPress(escapeKey);
-			SystemRandomWait(Speed.UI);
+			SystemWait(Speed.UI);
 			sim.Keyboard.KeyPress(inventoryKey);
-			SystemRandomWait(Speed.UI);
+			SystemWait(Speed.UI);
 		}
 
 		public static void MainMenuScreen()
 		{
 			sim.Keyboard.KeyPress(escapeKey);
-			SystemRandomWait(Speed.UI);
+			SystemWait(Speed.UI);
 			sim.Keyboard.KeyPress(escapeKey);
-			SystemRandomWait(Speed.UI);
+			SystemWait(Speed.UI);
 		}
 
 		#endregion Game Menu Navigation
@@ -382,96 +382,89 @@ namespace InventoryKamera
 
 		#region Delays
 
-		public static void SystemRandomWait(Speed speed = Speed.Normal)
+		public static void SystemWait(Speed speed = Speed.Normal)
 		{
 			Random r = new Random();
-			int value;
+			double value;
 			switch (speed)
 			{
 				case Speed.Fastest:
 					value = 10;
-					value += delay / 10;
 					break;
 
 				case Speed.Faster:
-					value = 100;
-					value += delay / 5;
+					value = 75;
 					break;
 
 				case Speed.Fast:
-					value = 250;
-					value += delay / 2;
+					value = 100;
 					break;
 
 				case Speed.Normal:
 					value = 500;
-					value += delay;
 					break;
 
 				case Speed.Slow:
-					value = 1000;
-					value += 3 * delay;
+					value = 750;
 					break;
 
 				case Speed.Slower:
-					value = 2000;
-					value += 3 * delay;
+					value = 1000;
 					break;
 
 				case Speed.Slowest:
-					value = 3000;
-					value += 3 * delay;
+					value = 2000;
 					break;
 
 				case Speed.CharacterUI:
-					value = 400;
-					value += delay;
+					value = 2000;
 					break;
 
 				case Speed.ArtifactIgnore:
-					value = r.Next(50, 70);
-					value += delay / 5;
+					value = r.Next(50, 60);
 					break;
 
 				case Speed.UI:
 					value = r.Next(1800, 2200);
-					value += 3 * delay;
 					break;
 
 				case Speed.SelectNextCharacter:
-					value = 600;
-					value += 2 * delay;
+					value = 700;
 					break;
 
 				case Speed.InventoryScroll:
 					value = 10;
-					value += delay / 10;
 					break;
 
 				case Speed.SelectNextInventoryItem:
 					value = 175;
-					value += delay / 3;
 					break;
 
 				default:
 					value = 1000;
 					break;
 			}
+			value *= delay;
 
-			Wait(value);
+			Wait(((int)value));
 		}
+
+		public static void SystemWait(float ms)
+        {
+			Wait((int)(ms * delay));
+        }
 
 		public static void Wait(int ms = 1000)
 		{
 			Thread.Sleep(ms);
 		}
 
-		public static void SetDelay(int _delay)
+		public static void SetDelay(double _delay)
 		{
 			delay = _delay;
 		}
 
-		public static int GetDelay()
+		public static double GetDelay()
 		{
 			return delay;
 		}

--- a/InventoryKamera/game/Navigation.cs
+++ b/InventoryKamera/game/Navigation.cs
@@ -384,7 +384,6 @@ namespace InventoryKamera
 
 		public static void SystemWait(Speed speed = Speed.Normal)
 		{
-			Random r = new Random();
 			double value;
 			switch (speed)
 			{
@@ -421,11 +420,11 @@ namespace InventoryKamera
 					break;
 
 				case Speed.ArtifactIgnore:
-					value = r.Next(50, 60);
+					value = 80;
 					break;
 
 				case Speed.UI:
-					value = r.Next(1800, 2200);
+					value = 2000;
 					break;
 
 				case Speed.SelectNextCharacter:
@@ -437,7 +436,7 @@ namespace InventoryKamera
 					break;
 
 				case Speed.SelectNextInventoryItem:
-					value = 175;
+					value = 200;
 					break;
 
 				default:

--- a/InventoryKamera/game/Navigation.cs
+++ b/InventoryKamera/game/Navigation.cs
@@ -147,7 +147,7 @@ namespace InventoryKamera
 		{
 			int buttonX = (int)(385 / 1280.0 * GetWidth());
 			int buttonY = (int)(35  / 720.0 * GetHeight());
-			SetCursorPos(WindowPosition.Left + buttonX, WindowPosition.Top + buttonY);
+			SetCursor(buttonX, buttonY);
 			Click();
 			SystemRandomWait(Speed.UI);
 		}
@@ -156,7 +156,7 @@ namespace InventoryKamera
 		{
 			int buttonX = (int)(448 / 1280.0 * GetWidth());
 			int buttonY = (int)(31 / 720.0 * GetHeight());
-			SetCursorPos(WindowPosition.Left + buttonX, WindowPosition.Top + buttonY);
+			SetCursor(buttonX, buttonY);
 			Click();
 			SystemRandomWait(Speed.UI);
 		}
@@ -165,7 +165,7 @@ namespace InventoryKamera
 		{
 			int buttonX = (int)(512 / 1280.0 * GetWidth());
 			int buttonY = (int)(40  / 720.0 * GetHeight());
-			SetCursorPos(WindowPosition.Left + buttonX, WindowPosition.Top + buttonY);
+			SetCursor(buttonX, buttonY);
 			Click();
 			SystemRandomWait(Speed.UI);
 		}
@@ -174,7 +174,7 @@ namespace InventoryKamera
 		{
 			int buttonX = (int)(636 / 1280.0 * GetWidth());
 			int buttonY = (int)(30  / 720.0 * GetHeight());
-			SetCursorPos(WindowPosition.Left + buttonX, WindowPosition.Top + buttonY);
+			SetCursor(buttonX, buttonY);
 			Click();
 			SystemRandomWait(Speed.UI);
 		}
@@ -189,7 +189,7 @@ namespace InventoryKamera
 				yOffset = (int)( 105 / 800.0 * GetHeight() );
 			}
 
-			SetCursorPos(GetPosition().Left + xOffset, GetPosition().Top + yOffset);
+			SetCursor(xOffset, yOffset);
 			Click();
 			SystemRandomWait(Speed.CharacterUI);
 		}
@@ -204,7 +204,7 @@ namespace InventoryKamera
 				yOffset = (int)( 245 / 800.0 * GetHeight() );
 			}
 
-			SetCursorPos(GetPosition().Left + xOffset, GetPosition().Top + yOffset);
+			SetCursor(xOffset, yOffset);
 			Click();
 			SystemRandomWait(Speed.CharacterUI);
 		}
@@ -219,7 +219,7 @@ namespace InventoryKamera
 				yOffset = (int)( 290 / 800.0 * GetHeight() );
 			}
 
-			SetCursorPos(GetPosition().Left + xOffset, GetPosition().Top + yOffset);
+			SetCursor(xOffset, yOffset);
 			Click();
 			SystemRandomWait(Speed.CharacterUI);
 		}
@@ -234,7 +234,7 @@ namespace InventoryKamera
 				yOffset = (int)( 400 / 800.0 * GetHeight() );
 			}
 
-			SetCursorPos(GetPosition().Left + xOffset, GetPosition().Top + yOffset);
+			SetCursor(xOffset, yOffset);
 			Click();
 			SystemRandomWait(Speed.SelectNextCharacter);
 		}
@@ -364,6 +364,11 @@ namespace InventoryKamera
 
 		[DllImport("user32.dll")]
 		public static extern bool SetCursorPos(int X, int Y);
+
+		public static bool SetCursor(int X, int Y)
+        {
+			return SetCursorPos(GetPosition().Left + X, GetPosition().Top + Y);
+		}
 
 		public static void Click()
 		{

--- a/InventoryKamera/scraping/ArtifactScraper.cs
+++ b/InventoryKamera/scraping/ArtifactScraper.cs
@@ -462,6 +462,7 @@ namespace InventoryKamera
 			artifactImages.Add(card);
 
 
+
             if (GetRarity(name) < Properties.Settings.Default.MinimumArtifactRarity)
 			{
 				artifactImages.ForEach(i => i.Dispose());
@@ -612,19 +613,20 @@ namespace InventoryKamera
 
 					// Get Main Stat
 					string mainStat = Scraper.AnalyzeText(n).ToLower().Trim();
-					n.Dispose();
+					
 
 					// Remove anything not a-z as well as removes spaces/underscores
 					mainStat = Regex.Replace(mainStat, @"[\W_0-9]", string.Empty);
 					// Replace double characters (ex. aanemodmgbonus). Seemed to be a somewhat common problem.
 					mainStat = Regex.Replace(mainStat, "(.)\\1+", "$1");
+					mainStat = Scraper.FindClosestStat(mainStat);
 
 					if (mainStat == "def" || mainStat == "atk" || mainStat == "hp")
 					{
-						mainStat += "%";
+						mainStat += "_";
 					}
-
-					return Scraper.FindClosestStat(mainStat);
+					n.Dispose();
+					return mainStat;
 			}
 		}
 

--- a/InventoryKamera/scraping/ArtifactScraper.cs
+++ b/InventoryKamera/scraping/ArtifactScraper.cs
@@ -22,7 +22,8 @@ namespace InventoryKamera
 		{
 			// Get Max artifacts from screen
 			int artifactCount = count == 0 ? ScanArtifactCount() : count;
-			var (rectangles, cols, rows) = GetPageOfItems();
+			int page = 0;
+			var (rectangles, cols, rows) = GetPageOfItems(page);
 			int fullPage = cols * rows;
 			int totalRows = (int)Math.Ceiling(artifactCount / (decimal)cols);
 			int cardsQueued = 0;
@@ -123,6 +124,8 @@ namespace InventoryKamera
 					}
 					Navigation.SystemRandomWait(Navigation.Speed.Fast);
 				}
+				++page;
+				(rectangles, cols, rows) = GetPageOfItems(page);
 			}
 		}
 
@@ -194,7 +197,7 @@ namespace InventoryKamera
 			}
 		}
 
-		private static (List<Rectangle> rectangles, int cols, int rows) GetPageOfItems()
+		private static (List<Rectangle> rectangles, int cols, int rows) GetPageOfItems(int page)
 		{
 			// Screenshot of inventory
 			using (Bitmap screenshot = Navigation.CaptureWindow())
@@ -209,7 +212,7 @@ namespace InventoryKamera
 						screenshot.Save($"./logging/artifacts/ArtifactInventory.png");
 						using (Graphics g = Graphics.FromImage(screenshot))
 							rectangles.ForEach(r => g.DrawRectangle(new Pen(Color.Green, 2), r));
-						screenshot.Save($"./logging/artifacts/ArtifactInventory_{cols}x{rows}.png");
+						screenshot.Save($"./logging/artifacts/ArtifactInventory{page}_{cols}x{rows}.png");
 					}
 					return (rectangles, cols, rows);
 				}
@@ -359,12 +362,6 @@ namespace InventoryKamera
 
 				// Sort by row then by column within each row
 				rectangles = rectangles.OrderBy(r => r.Top).ThenBy(r => r.Left).ToList();
-
-				Debug.WriteLine($"{colCoords.Count} columns: ");
-				colCoords.ForEach(c => Debug.Write(c + ", ")); Debug.WriteLine("");
-				Debug.WriteLine($"{rowCoords.Count} rows: ");
-				rowCoords.ForEach(c => Debug.Write(c + ", ")); Debug.WriteLine("");
-				Debug.WriteLine($"{rectangles.Count} rectangles");
 
 				return (rectangles, colCoords.Count, rowCoords.Count);
 			}

--- a/InventoryKamera/scraping/ArtifactScraper.cs
+++ b/InventoryKamera/scraping/ArtifactScraper.cs
@@ -83,7 +83,7 @@ namespace InventoryKamera
 					Rectangle item = rectangles[i];
 					Navigation.SetCursor(item.Center().X, item.Center().Y + offset);
 					Navigation.Click();
-					Navigation.SystemRandomWait(Navigation.Speed.SelectNextInventoryItem);
+					Navigation.SystemWait(Navigation.Speed.SelectNextInventoryItem);
 
 					// Queue card for scanning
 					QueueScan(cardsQueued);
@@ -109,7 +109,7 @@ namespace InventoryKamera
 					{
 						Navigation.sim.Mouse.VerticalScroll(-1);
 					}
-					Navigation.SystemRandomWait(Navigation.Speed.Fast);
+					Navigation.SystemWait(Navigation.Speed.Fast);
 				}
 				else
 				{
@@ -122,7 +122,7 @@ namespace InventoryKamera
 					{
 						Navigation.sim.Mouse.VerticalScroll(-1);
 					}
-					Navigation.SystemRandomWait(Navigation.Speed.Fast);
+					Navigation.SystemWait(Navigation.Speed.Fast);
 				}
 				++page;
 				(rectangles, cols, rows) = GetPageOfItems(page);

--- a/InventoryKamera/scraping/CharacterScraper.cs
+++ b/InventoryKamera/scraping/CharacterScraper.cs
@@ -32,6 +32,17 @@ namespace InventoryKamera
 				Navigation.SelectNextCharacter();
 				UserInterface.ResetCharacterDisplay();
 			}
+            for (int i = 0; i < 4; i++)
+            {
+                if (Characters.ElementAt(i).Name.ToLower() == "tartaglia")
+                {
+                    for (i = 0; i < Characters.Count; i++)
+                    {
+						Characters[i].Talents["auto"] -= 1;
+                    }
+					break;
+                }
+            }
 			return Characters;
 		}
 

--- a/InventoryKamera/scraping/CharacterScraper.cs
+++ b/InventoryKamera/scraping/CharacterScraper.cs
@@ -11,44 +11,60 @@ namespace InventoryKamera
 	public static class CharacterScraper
 	{
 		private static NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
-		private static string firstCharacterName = null;
-		private static List<Character> Characters = new List<Character>();
 
-		public static List<Character> ScanCharacters()
+		public static void ScanCharacters(ref List<Character> Characters)
 		{
-			// first character name is used to stop scanning characters
-			int characterCount = 0;
-			firstCharacterName = null; // Static variable might already be set
+			int viewed = 0;
+			string first = null;
+
 			UserInterface.ResetCharacterDisplay();
-			while (ScanCharacter(out Character character) || characterCount <= 4)
+
+			while (true)
 			{
+				var character = ScanCharacter(first);
+				if (Characters.Count > 0 && character.Name == Characters.ElementAt(0).Name) break;
 				if (character.IsValid())
 				{
 					Characters.Add(character);
 					UserInterface.IncrementCharacterCount();
 					Logger.Info("Scanned {0} successfully", character.Name);
-					characterCount++;
+					if (Characters.Count == 1) first = character.Name;
 				}
+                else 
+				{
+					string error = "";
+					if (!character.HasValidName()) error += "Invalid character name\n";
+					if (!character.HasValidLevel()) error += "Invalid level\n";
+					if (!character.HasValidElement()) error += "Invalid element\n";
+					if (!character.HasValidConstellation()) error += "Invalid constellation\n";
+					if (!character.HasValidTalents()) error += "Invalid talents\n";
+					Logger.Error("Failed to scan character\n" + error + character);
+
+				}
+
 				Navigation.SelectNextCharacter();
 				UserInterface.ResetCharacterDisplay();
+
+				if (++viewed > 3 && Characters.Count < 1) break;
 			}
-            for (int i = 0; i < 4; i++)
+
+            // Childe passive buff fix
+            foreach (var character in Characters.Take(4))
             {
-                if (Characters.ElementAt(i).Name.ToLower() == "tartaglia")
+				if (character.Name.ToLower() == "tartaglia")
                 {
-                    for (i = 0; i < Characters.Count; i++)
-                    {
+					for (int i = 0; i < Characters.Count; i++)
+					{
 						Characters[i].Talents["auto"] -= 1;
-                    }
+					}
 					break;
-                }
+				}
             }
-			return Characters;
 		}
 
-		private static bool ScanCharacter(out Character character)
+		private static Character ScanCharacter(string firstCharacter)
 		{
-			character = new Character();
+			var character = new Character();
 			Navigation.SelectCharacterAttributes();
 			string name = null;
 			string element = null;
@@ -60,70 +76,70 @@ namespace InventoryKamera
 			{
 				if (string.IsNullOrWhiteSpace(name)) UserInterface.AddError("Could not determine character's name");
 				if (string.IsNullOrWhiteSpace(element)) UserInterface.AddError("Could not determine character's element");
-				return false;
+				return character;
 			}
 
-			// Check if character was first scanned
-			if (name != firstCharacterName)
-			{
-				if (string.IsNullOrWhiteSpace(firstCharacterName))
-					firstCharacterName = name;
+			character.Name = name;
+			character.Element = element;
 
+			// Check if character was first scanned
+			if (name != firstCharacter)
+			{
 				bool ascended = false;
 				// Scan Level and ascension
 				int level = ScanLevel(ref ascended);
 				if (level == -1)
 				{
 					UserInterface.AddError($"Could not determine {name}'s level");
-					return false;
+					return character;
 				}
+				character.Level = level;
+				character.Ascended = ascended;
 
 				// Scan Experience
 				//experience = ScanExperience();
-				Navigation.SystemRandomWait(Navigation.Speed.Normal);
+				//Navigation.SystemRandomWait(Navigation.Speed.Normal);
 
 				// Scan Constellation
 				Navigation.SelectCharacterConstellation();
-				int constellation = ScanConstellations();
-				Navigation.SystemRandomWait(Navigation.Speed.Normal);
+				character.Constellation = ScanConstellations();
+				Navigation.SystemWait(Navigation.Speed.Normal);
 
 				// Scan Talents
 				Navigation.SelectCharacterTalents();
-				int[] talents = ScanTalents(name);
-				Navigation.SystemRandomWait(Navigation.Speed.Normal);
+				character.Talents = ScanTalents(name);
+				Navigation.SystemWait(Navigation.Speed.Normal);
 
 				// Scale down talents due to constellations
-				if (constellation >= 3)
+				if (character.Constellation >= 3)
 				{
 					if (Scraper.Characters.ContainsKey(name.ToLower()))
 					{
 						// get talent if character
-						if (constellation >= 5)
+						if (character.Constellation >= 5)
 						{
-							talents[1] -= 3;
-							talents[2] -= 3;
+							character.Talents["skill"] -= 3;
+							character.Talents["burst"] -= 3;
 						}
 						else if ((string)Scraper.Characters[name.ToLower()]["ConstellationOrder"][0] == "skill")
 						{
-							talents[1] -= 3;
+							character.Talents["skill"] -= 3;
 						}
 						else
 						{
-							talents[2] -= 3;
+							character.Talents["burst"] -= 3;
 						}
 					}
 					else
-						return false;
+						return character;
 				}
 
-				var weaponType = Scraper.Characters[name.ToLower()]["WeaponType"].ToObject<int>();
+				character.WeaponType = Scraper.Characters[name.ToLower()]["WeaponType"].ToObject<WeaponType>();
 
-				int experience = 0;
-				character = new Character(name, element, level, ascended, experience, constellation, talents, (WeaponType)weaponType);
-				return true;
+				return character;
 			}
 			Logger.Info("Repeat character {0} detected. Finishing character scan...", name);
-			return false;
+			return character;
 		}
 
 		public static string ScanMainCharacterName()
@@ -182,7 +198,7 @@ namespace InventoryKamera
 
 			do
 			{
-				Navigation.SystemRandomWait(Navigation.Speed.Fast);
+				Navigation.SystemWait(Navigation.Speed.Fast);
 				using (Bitmap bm = Navigation.CaptureRegion(region))
 				{
 					Bitmap n = Scraper.ConvertToGrayscale(bm);
@@ -229,7 +245,7 @@ namespace InventoryKamera
 					}
 				}
 				attempts++;
-				Navigation.SystemRandomWait(Navigation.Speed.Normal);
+				Navigation.SystemWait(Navigation.Speed.Normal);
 			} while (( string.IsNullOrWhiteSpace(name) || string.IsNullOrEmpty(element) ) && ( attempts < maxAttempts ));
 			name = null;
 			element = null;
@@ -279,7 +295,7 @@ namespace InventoryKamera
 					n.Dispose();
 					bm.Dispose();
 				}
-				Navigation.SystemRandomWait(Navigation.Speed.Normal);
+				Navigation.SystemWait(Navigation.Speed.Normal);
 			} while (level == -1);
 
 			return -1;
@@ -350,8 +366,8 @@ namespace InventoryKamera
 				Navigation.SetCursor((int)( 1130 / 1280.0 * Navigation.GetWidth() ), yOffset);
 				Navigation.Click();
 
-				Navigation.Speed speed = constellation == 0 ? Navigation.Speed.Normal : Navigation.Speed.Fast;
-				Navigation.SystemRandomWait(speed);
+				var pause = constellation == 0 ? 700 : 550;
+				Navigation.SystemWait(pause);
 
 				// Grab Color
 				using (Bitmap region = Navigation.CaptureRegion(constActivate))
@@ -371,9 +387,14 @@ namespace InventoryKamera
 			return constellation;
 		}
 
-		private static int[] ScanTalents(string name)
+		private static Dictionary<string, int> ScanTalents(string name)
 		{
-			int[] talents = {-1,-1,-1};
+			var talents = new Dictionary<string, int>
+			{
+				{ "auto" , -1 },
+				{ "skill", -1 },
+				{ "burst", -1 }
+			};
 
 			int specialOffset = 0;
 
@@ -384,10 +405,7 @@ namespace InventoryKamera
 			var xRef = 1280.0;
 			var yRef = 720.0;
 
-			if (Navigation.GetAspectRatio() == new Size(8, 5))
-			{
-				yRef = 800.0;
-			}
+			if (Navigation.GetAspectRatio() == new Size(8, 5)) yRef = 800.0;
 
 			Rectangle region =  new RECT(
 				Left:   (int)( 160 / xRef * Navigation.GetWidth() ),
@@ -397,15 +415,28 @@ namespace InventoryKamera
 
 			for (int i = 0; i < 3; i++)
 			{
+				string talent;
 				// Change y-offset for talent clicking
 				int yOffset = (int)( 110 / yRef * Navigation.GetHeight() ) + ( i + ( ( i == 2 ) ? specialOffset : 0 ) ) * (int)(60 / yRef * Navigation.GetHeight() );
 
 				Navigation.SetCursor((int)(1130 / xRef * Navigation.GetWidth()), yOffset);
 				Navigation.Click();
-				Navigation.Speed speed = i == 0 ? Navigation.Speed.Normal : Navigation.Speed.Fast;
-				Navigation.SystemRandomWait(speed);
+				int pause = i == 0 ? 700 : 550;
+				Navigation.SystemWait(pause);
+                switch (i)
+                {
+					default:
+						talent = "auto";
+						break;
+					case 1:
+						talent = "skill";
+						break;
+					case 2:
+						talent = "burst";
+						break;
+                }
 
-				while (talents[i] < 1 || talents[i] > 15)
+                while (talents[talent] < 1 || talents[talent] > 15)
 				{
 					Bitmap talentLevel = Navigation.CaptureRegion(region);
 
@@ -422,7 +453,7 @@ namespace InventoryKamera
 					{
 						if (level >= 1 && level <= 15)
 						{
-							talents[i] = level;
+							talents[talent] = level;
 							UserInterface.SetCharacter_Talent(talentLevel, text, i);
 						}
 					}

--- a/InventoryKamera/scraping/CharacterScraper.cs
+++ b/InventoryKamera/scraping/CharacterScraper.cs
@@ -16,6 +16,7 @@ namespace InventoryKamera
 		{
 			int viewed = 0;
 			string first = null;
+			HashSet<string> scanned = new HashSet<string>();
 
 			UserInterface.ResetCharacterDisplay();
 
@@ -25,10 +26,17 @@ namespace InventoryKamera
 				if (Characters.Count > 0 && character.Name == Characters.ElementAt(0).Name) break;
 				if (character.IsValid())
 				{
-					Characters.Add(character);
-					UserInterface.IncrementCharacterCount();
-					Logger.Info("Scanned {0} successfully", character.Name);
-					if (Characters.Count == 1) first = character.Name;
+					if (!scanned.Contains(character.Name))
+					{
+						Characters.Add(character);
+						UserInterface.IncrementCharacterCount();
+						Logger.Info("Scanned {0} successfully", character.Name);
+						if (Characters.Count == 1) first = character.Name;
+					}
+					else
+                    {
+						Logger.Info("Prevented {0} duplicate scan", character.Name);
+                    }
 				}
                 else 
 				{
@@ -39,7 +47,6 @@ namespace InventoryKamera
 					if (!character.HasValidConstellation()) error += "Invalid constellation\n";
 					if (!character.HasValidTalents()) error += "Invalid talents\n";
 					Logger.Error("Failed to scan character\n" + error + character);
-
 				}
 
 				Navigation.SelectNextCharacter();
@@ -57,6 +64,7 @@ namespace InventoryKamera
 					{
 						Characters[i].Talents["auto"] -= 1;
 					}
+					Logger.Info("Tartaglia in on-field party, applied auto attack fix.");
 					break;
 				}
             }
@@ -96,6 +104,9 @@ namespace InventoryKamera
 				character.Level = level;
 				character.Ascended = ascended;
 
+				Logger.Info("{name:l} Level: {level:l}", character.Name, character.Level);
+				Logger.Info("{name:l} Ascended: {ascended:l}", character.Name, character.Ascended);
+
 				// Scan Experience
 				//experience = ScanExperience();
 				//Navigation.SystemRandomWait(Navigation.Speed.Normal);
@@ -103,11 +114,13 @@ namespace InventoryKamera
 				// Scan Constellation
 				Navigation.SelectCharacterConstellation();
 				character.Constellation = ScanConstellations();
+				Logger.Info("{name:l} Constellation: {constellation:l}", character.Name, character.Constellation);
 				Navigation.SystemWait(Navigation.Speed.Normal);
 
 				// Scan Talents
 				Navigation.SelectCharacterTalents();
 				character.Talents = ScanTalents(name);
+				Logger.Info("{name:l} Talents: {talents:l}", character.Name, character.Talents);
 				Navigation.SystemWait(Navigation.Speed.Normal);
 
 				// Scale down talents due to constellations

--- a/InventoryKamera/scraping/CharacterScraper.cs
+++ b/InventoryKamera/scraping/CharacterScraper.cs
@@ -347,8 +347,7 @@ namespace InventoryKamera
 					yOffset = (int)( ( 225 + ( constellation * 75 ) ) / yReference * Navigation.GetHeight() );
 				}
 
-				Navigation.SetCursorPos(Navigation.GetPosition().Left + (int)( 1130 / 1280.0 * Navigation.GetWidth() ),
-										Navigation.GetPosition().Top + yOffset);
+				Navigation.SetCursor((int)( 1130 / 1280.0 * Navigation.GetWidth() ), yOffset);
 				Navigation.Click();
 
 				Navigation.Speed speed = constellation == 0 ? Navigation.Speed.Normal : Navigation.Speed.Fast;
@@ -401,7 +400,7 @@ namespace InventoryKamera
 				// Change y-offset for talent clicking
 				int yOffset = (int)( 110 / yRef * Navigation.GetHeight() ) + ( i + ( ( i == 2 ) ? specialOffset : 0 ) ) * (int)(60 / yRef * Navigation.GetHeight() );
 
-				Navigation.SetCursorPos(Navigation.GetPosition().Left + (int)( 1130 / xRef * Navigation.GetWidth() ), Navigation.GetPosition().Top + yOffset);
+				Navigation.SetCursor((int)(1130 / xRef * Navigation.GetWidth()), yOffset);
 				Navigation.Click();
 				Navigation.Speed speed = i == 0 ? Navigation.Speed.Normal : Navigation.Speed.Fast;
 				Navigation.SystemRandomWait(speed);

--- a/InventoryKamera/scraping/MaterialScraper.cs
+++ b/InventoryKamera/scraping/MaterialScraper.cs
@@ -75,7 +75,7 @@ namespace InventoryKamera
 				foreach (var rectangle in r)
 				{
 					// Select Material
-					Navigation.SetCursorPos(Navigation.GetPosition().Left + rectangle.Center().X, Navigation.GetPosition().Top + rectangle.Center().Y);
+					Navigation.SetCursor(rectangle.Center().X, rectangle.Center().Y);
 					Navigation.Click();
 					Navigation.SystemRandomWait(Navigation.Speed.SelectNextInventoryItem);
 
@@ -113,7 +113,7 @@ namespace InventoryKamera
 					Navigation.Wait(150);
 				}
 
-				Navigation.SetCursorPos(Navigation.GetPosition().Left + r.Last().Center().X, Navigation.GetPosition().Top + r.Last().Center().Y);
+				Navigation.SetCursor(r.Last().Center().X, r.Last().Center().Y);
 				Navigation.Click();
 				Navigation.Wait(150);
 				// Scroll to next page
@@ -164,7 +164,7 @@ namespace InventoryKamera
 			{
 				// Select Material
 				Rectangle rectangle = rectangles[i];
-				Navigation.SetCursorPos(Navigation.GetPosition().Left + rectangle.Center().X, Navigation.GetPosition().Top + rectangle.Center().Y);
+				Navigation.SetCursor(rectangle.Center().X, rectangle.Center().Y);
 				Navigation.Click();
 				Navigation.SystemRandomWait(Navigation.Speed.SelectNextInventoryItem);
 

--- a/InventoryKamera/scraping/MaterialScraper.cs
+++ b/InventoryKamera/scraping/MaterialScraper.cs
@@ -79,7 +79,7 @@ namespace InventoryKamera
 					// Select Material
 					Navigation.SetCursor(rectangle.Center().X, rectangle.Center().Y);
 					Navigation.Click();
-					Navigation.SystemRandomWait(Navigation.Speed.SelectNextInventoryItem);
+					Navigation.SystemWait(Navigation.Speed.SelectNextInventoryItem);
 
 					material.name = ScanMaterialName(section, out Bitmap nameplate);
 					material.count = 0;
@@ -143,10 +143,10 @@ namespace InventoryKamera
 								}
 							}
 						}
-						Navigation.SystemRandomWait(Navigation.Speed.InventoryScroll);
+						Navigation.SystemWait(Navigation.Speed.InventoryScroll);
 					}
 				}
-				Navigation.SystemRandomWait(Navigation.Speed.Normal);
+				Navigation.SystemWait(Navigation.Speed.Normal);
 				++page;
 			}
 
@@ -155,7 +155,7 @@ namespace InventoryKamera
 			for (int i = 0; i < 20; i++)
 			{
 				Navigation.sim.Mouse.VerticalScroll(-1);
-				Navigation.SystemRandomWait(Navigation.Speed.InventoryScroll);
+				Navigation.SystemWait(Navigation.Speed.InventoryScroll);
 			}
 
 			Navigation.Wait(500);
@@ -168,7 +168,7 @@ namespace InventoryKamera
 				Rectangle rectangle = rectangles[i];
 				Navigation.SetCursor(rectangle.Center().X, rectangle.Center().Y);
 				Navigation.Click();
-				Navigation.SystemRandomWait(Navigation.Speed.SelectNextInventoryItem);
+				Navigation.SystemWait(Navigation.Speed.SelectNextInventoryItem);
 
 				material.name = ScanMaterialName(section, out Bitmap nameplate);
 				material.count = 0;

--- a/InventoryKamera/scraping/MaterialScraper.cs
+++ b/InventoryKamera/scraping/MaterialScraper.cs
@@ -45,6 +45,8 @@ namespace InventoryKamera
 
 	public static class MaterialScraper
 	{
+		private static NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+
 		public static void Scan_Materials(InventorySection section, ref Inventory inventory)
 		{
 			if (!inventory.Materials.Contains(new Material("Mora", 0)))
@@ -244,9 +246,13 @@ namespace InventoryKamera
 		{
 			using (var gray = Scraper.ConvertToGrayscale(screenshot))
 			{
-				var input = Scraper.AnalyzeText(gray).Split(' ').ToList();
+				var invert = (Bitmap)gray.Clone();
+				Scraper.SetInvert(ref invert);
+				var input = Scraper.AnalyzeText(invert).Split(' ').ToList();
+				Logger.Debug("Scanned mora input: {0}", input.ToString());
 				input.RemoveAll(e => Regex.IsMatch(e.Trim(), @"[^0-9]") || string.IsNullOrWhiteSpace(e.Trim()));
 				var mora = input.LastOrDefault();
+				Logger.Debug("Parsed mora input: {0}", mora);
 				return mora;
 			}
 		}
@@ -412,12 +418,6 @@ namespace InventoryKamera
 				// Sort by row then by column within each row
 				rectangles = rectangles.OrderBy(r => r.Top).ThenBy(r => r.Left).ToList();
 
-				Debug.WriteLine($"{colCoords.Count} columns: ");
-				colCoords.ForEach(c => Debug.Write(c + ", ")); Debug.WriteLine("");
-				Debug.WriteLine($"{rowCoords.Count} rows: ");
-				rowCoords.ForEach(c => Debug.Write(c + ", ")); Debug.WriteLine("");
-				Debug.WriteLine($"{rectangles.Count} rectangles");
-
 				return (rectangles, colCoords.Count, rowCoords.Count);
 			}
 		}
@@ -507,12 +507,8 @@ namespace InventoryKamera
 
 					_ = int.TryParse(cleaned, out int count);
 
-					Debug.WriteLine($"{old_text} -> {cleaned} -> {count}");
+					Logger.Debug($"{old_text} -> {cleaned} -> {count}");
 
-					//if (count > 3000 || count == 0)
-					//{
-					//	//Navigation.DisplayBitmap(n);
-					//}
 					copy.Dispose();
 					n.Dispose();
 					return count;

--- a/InventoryKamera/scraping/Scraper.cs
+++ b/InventoryKamera/scraping/Scraper.cs
@@ -472,12 +472,12 @@ namespace InventoryKamera
 					delayOffset = 10;
 
 				// Do mouse movement to first and second UI element in Inventory
-				Navigation.SetCursorPos(Navigation.GetPosition().Left + item1.Center().X, Navigation.GetPosition().Top + item1.Center().Y);
+				Navigation.SetCursor(item1.Center().X, item1.Center().Y);
 				Navigation.Click();
 				Navigation.Wait(Navigation.GetDelay() - delayOffset);
 
 				Rectangle item2 = rectangles[1];
-				Navigation.SetCursorPos(Navigation.GetPosition().Left + item2.Center().X, Navigation.GetPosition().Top + item2.Center().Y);
+				Navigation.SetCursor(item2.Center().X, item2.Center().Y);
 				Navigation.Click();
 				Navigation.Wait(Navigation.GetDelay() - delayOffset);
 
@@ -502,7 +502,7 @@ namespace InventoryKamera
 				}
 
 				Rectangle item3 = rectangles[2];
-				Navigation.SetCursorPos(Navigation.GetPosition().Left + item3.Center().X, Navigation.GetPosition().Top + item3.Center().Y);
+				Navigation.SetCursor(item3.Center().X, item3.Center().Y);
 				Navigation.Click();
 				Navigation.Wait(Navigation.GetDelay() - delayOffset);
 
@@ -532,7 +532,7 @@ namespace InventoryKamera
 					Navigation.SetDelay(Navigation.GetDelay() - delayOffset);
 					//Navigation.SystemRandomWait();
 
-					Navigation.SetCursorPos(Navigation.GetPosition().Left + item1.Center().X, Navigation.GetPosition().Top + item1.Center().Y);
+					Navigation.SetCursor(item1.Center().X, item1.Center().Y);
 					Navigation.Click();
 					//Navigation.SystemRandomWait();
 				}
@@ -553,14 +553,14 @@ namespace InventoryKamera
 
 			// set back to first element
 			Navigation.SystemRandomWait(Navigation.Speed.Slowest);
-			Navigation.SetCursorPos(Navigation.GetPosition().Left + item1.Center().X, Navigation.GetPosition().Top + item1.Center().Y);
+			Navigation.SetCursor(item1.Center().X, item1.Center().Y);
 			Navigation.Click();
 			Navigation.SystemRandomWait(Navigation.Speed.Slower);
 		}
 
-		#region Image Operations
+        #region Image Operations
 
-		public static Bitmap ResizeImage(System.Drawing.Image image, int width, int height)
+        public static Bitmap ResizeImage(System.Drawing.Image image, int width, int height)
 		{
 			var destRect = new Rectangle(0, 0, width, height);
 			var destImage = new Bitmap(width, height);
@@ -598,8 +598,28 @@ namespace InventoryKamera
 
 			return diff[0] < 10 && diff[1] < 10 && diff[2] < 10;
 		}
+		internal static Color ClosestColor(List<Color> colors, ImageStatistics color)
+		{
+			var c2 = Color.FromArgb((int)color.Red.Mean, (int)color.Green.Mean, (int)color.Blue.Mean);
+			var diff = colors.Select(x => new { Value = x, Diff = GetColorDifference(x, c2) }).ToList();
 
-		public static Bitmap ConvertToGrayscale(Bitmap bitmap)
+			Logger.Debug("Average Color: {0}", c2);
+
+			foreach (var c in colors)
+            {
+                if (CompareColors(c, c2)) return c;
+            }
+
+            return diff.Find(x=> x.Diff == diff.Min(y=>y.Diff)).Value;
+		}
+
+        private static int GetColorDifference(Color c, Color c2)
+        {
+			int r = c.R - c2.R, g = c.G - c2.G, b = c.B - c2.B;
+			return r*r + g*g + b*b;
+		}
+
+        public static Bitmap ConvertToGrayscale(Bitmap bitmap)
 		{
 			return new Grayscale(0.2125, 0.7154, 0.0721).Apply(bitmap);
 		}

--- a/InventoryKamera/scraping/Scraper.cs
+++ b/InventoryKamera/scraping/Scraper.cs
@@ -474,12 +474,12 @@ namespace InventoryKamera
 				// Do mouse movement to first and second UI element in Inventory
 				Navigation.SetCursor(item1.Center().X, item1.Center().Y);
 				Navigation.Click();
-				Navigation.Wait(Navigation.GetDelay() - delayOffset);
+				Navigation.Wait(((int)Navigation.GetDelay()) - delayOffset);
 
 				Rectangle item2 = rectangles[1];
 				Navigation.SetCursor(item2.Center().X, item2.Center().Y);
 				Navigation.Click();
-				Navigation.Wait(Navigation.GetDelay() - delayOffset);
+				Navigation.Wait(((int)Navigation.GetDelay()) - delayOffset);
 
 				// Take image after second click
 				if (Navigation.GetAspectRatio() == new Size(16, 9))
@@ -504,7 +504,7 @@ namespace InventoryKamera
 				Rectangle item3 = rectangles[2];
 				Navigation.SetCursor(item3.Center().X, item3.Center().Y);
 				Navigation.Click();
-				Navigation.Wait(Navigation.GetDelay() - delayOffset);
+				Navigation.Wait(((int)Navigation.GetDelay()) - delayOffset);
 
 				// Take image after third click
 				if (Navigation.GetAspectRatio() == new Size(16, 9))
@@ -552,10 +552,10 @@ namespace InventoryKamera
 			card1.Dispose(); card2.Dispose();
 
 			// set back to first element
-			Navigation.SystemRandomWait(Navigation.Speed.Slowest);
+			Navigation.SystemWait(Navigation.Speed.Slowest);
 			Navigation.SetCursor(item1.Center().X, item1.Center().Y);
 			Navigation.Click();
-			Navigation.SystemRandomWait(Navigation.Speed.Slower);
+			Navigation.SystemWait(Navigation.Speed.Slower);
 		}
 
         #region Image Operations

--- a/InventoryKamera/scraping/WeaponScraper.cs
+++ b/InventoryKamera/scraping/WeaponScraper.cs
@@ -45,7 +45,7 @@ namespace InventoryKamera
 					Rectangle item = rectangles[i];
 					Navigation.SetCursor(item.Center().X, item.Center().Y + offset);
 					Navigation.Click();
-					Navigation.SystemRandomWait(Navigation.Speed.SelectNextInventoryItem);
+					Navigation.SystemWait(Navigation.Speed.SelectNextInventoryItem);
 
 					// Queue card for scanning
 					QueueScan(cardsQueued);
@@ -71,7 +71,7 @@ namespace InventoryKamera
 					{
 						Navigation.sim.Mouse.VerticalScroll(-1);
 					}
-					Navigation.SystemRandomWait(Navigation.Speed.Fast);
+					Navigation.SystemWait(Navigation.Speed.Fast);
 				}
 				else
 				{
@@ -84,7 +84,7 @@ namespace InventoryKamera
 					{
 						Navigation.sim.Mouse.VerticalScroll(-1);
 					}
-					Navigation.SystemRandomWait(Navigation.Speed.Fast);
+					Navigation.SystemWait(Navigation.Speed.Fast);
 				}
 				++page;
 				(rectangles, cols, rows) = GetPageOfItems(page);

--- a/InventoryKamera/scraping/WeaponScraper.cs
+++ b/InventoryKamera/scraping/WeaponScraper.cs
@@ -28,9 +28,6 @@ namespace InventoryKamera
 			int offset = 0;
 			UserInterface.SetWeapon_Max(weaponCount);
 
-			// TODO: Rewrite this method to allow for scanning enhancement ore quantities
-			// weaponCount += 3;
-
 			// Determine Delay if delay has not been found before
 			// Scraper.FindDelay(rectangles);
 
@@ -45,7 +42,7 @@ namespace InventoryKamera
 				for (int i = cardsRemaining < fullPage ? ( rows - ( totalRows - rowsQueued ) ) * cols : 0; i < rectangles.Count; i++)
 				{
 					Rectangle item = rectangles[i];
-					Navigation.SetCursorPos(Navigation.GetPosition().Left + item.Center().X, Navigation.GetPosition().Top + item.Center().Y + offset);
+					Navigation.SetCursor(item.Center().X, item.Center().Y + offset);
 					Navigation.Click();
 					Navigation.SystemRandomWait(Navigation.Speed.SelectNextInventoryItem);
 
@@ -469,36 +466,21 @@ namespace InventoryKamera
 			return new Weapon(name, level, ascended, refinementLevel, locked, equippedCharacter, id, rarity);
 		}
 
-		private static int GetRarity(Bitmap bm, double scale = 1.0)
+		private static int GetRarity(Bitmap bm)
 		{
-			using (var scaled = Scraper.ScaleImage(bm, scale))
-			{
-				int x = (int)(0.025 * scaled.Width);
-				int y = (int)(0.20 * scaled.Height);
+			var averageColor = new ImageStatistics(bm);
 
-				if (scale != 1.0)
-                {
-					var random = new Random();
-					x = random.Next(scaled.Width);
-					y = random.Next(scaled.Height);
-                }
+			Color fiveStar    = Color.FromArgb(255, 188, 105,  50);
+			Color fourStar    = Color.FromArgb(255, 161,  86, 224);
+			Color threeStar   = Color.FromArgb(255,  81, 127, 203);
+			Color twoStar     = Color.FromArgb(255,  42, 143, 114);
+			Color oneStar     = Color.FromArgb(255, 114, 119, 138);
 
-				Color rarityColor = bm.GetPixel(x,y);
+			var colors = new List<Color> { Color.Black, oneStar, twoStar, threeStar, fourStar, fiveStar };
 
-				Color fiveStar    = Color.FromArgb(255, 188, 105,  50);
-				Color fourStar    = Color.FromArgb(255, 161,  86, 224);
-				Color threeStar   = Color.FromArgb(255,  81, 127, 203);
-				Color twoStar     = Color.FromArgb(255,  42, 143, 114);
-				Color oneStar     = Color.FromArgb(255, 114, 119, 138);
+			var c = Scraper.ClosestColor(colors, averageColor);
 
-				if (Scraper.CompareColors(fiveStar, rarityColor)) return 5;
-				else if (Scraper.CompareColors(fourStar, rarityColor)) return 4;
-				else if (Scraper.CompareColors(threeStar, rarityColor)) return 3;
-				else if (Scraper.CompareColors(twoStar, rarityColor)) return 2;
-				else if (Scraper.CompareColors(oneStar, rarityColor)) return 1;
-				else if (Scraper.CompareColors(Color.White, rarityColor)) return GetRarity(bm, scale);
-				else return scale >= 2 ? 10 : GetRarity(bm, scale + 0.1);
-			}
+			return colors.IndexOf(c);
 		}
 
 		public static bool IsEnhancementMaterial(Bitmap nameBitmap)

--- a/InventoryKamera/scraping/WeaponScraper.cs
+++ b/InventoryKamera/scraping/WeaponScraper.cs
@@ -20,7 +20,8 @@ namespace InventoryKamera
 		{
 			// Determine maximum number of weapons to scan
 			int weaponCount = count == 0 ? ScanWeaponCount(): count;
-			var (rectangles, cols, rows) = GetPageOfItems();
+			int page = 0;
+			var (rectangles, cols, rows) = GetPageOfItems(page);
 			int fullPage = cols * rows;
 			int totalRows = (int)Math.Ceiling(weaponCount / (decimal)cols);
 			int cardsQueued = 0;
@@ -85,6 +86,8 @@ namespace InventoryKamera
 					}
 					Navigation.SystemRandomWait(Navigation.Speed.Fast);
 				}
+				++page;
+				(rectangles, cols, rows) = GetPageOfItems(page);
 			}
 		}
 
@@ -140,7 +143,7 @@ namespace InventoryKamera
 			}
 		}
 
-		private static (List<Rectangle> rectangles, int cols, int rows) GetPageOfItems()
+		private static (List<Rectangle> rectangles, int cols, int rows) GetPageOfItems(int page)
 		{
 			// Screenshot of inventory
 			using (Bitmap screenshot = Navigation.CaptureWindow())
@@ -155,7 +158,7 @@ namespace InventoryKamera
 						using (Graphics g = Graphics.FromImage(screenshot))
 							rectangles.ForEach(r => g.DrawRectangle(new Pen(Color.Green, 2), r));
 						
-						screenshot.Save($"./logging/weapons/WeaponInventory_{cols}x{rows}.png");
+						screenshot.Save($"./logging/weapons/WeaponInventory{page}_{cols}x{rows}.png");
 					}
 					return (rectangles, cols, rows);
 				}
@@ -305,12 +308,6 @@ namespace InventoryKamera
 
 				// Sort by row then by column within each row
 				rectangles = rectangles.OrderBy(r => r.Top).ThenBy(r => r.Left).ToList();
-
-				Debug.WriteLine($"{colCoords.Count} columns: ");
-				colCoords.ForEach(c => Debug.Write(c + ", ")); Debug.WriteLine("");
-				Debug.WriteLine($"{rowCoords.Count} rows: ");
-				rowCoords.ForEach(c => Debug.Write(c + ", ")); Debug.WriteLine("");
-				Debug.WriteLine($"{rectangles.Count} rectangles");
 				
 				return (rectangles, colCoords.Count, rowCoords.Count);
 			}

--- a/InventoryKamera/ui/UserInterface.cs
+++ b/InventoryKamera/ui/UserInterface.cs
@@ -93,7 +93,7 @@ namespace InventoryKamera
 			}
 			catch (Exception e)
 			{
-				Debug.WriteLine($"Problem updating picturebox {pictureBox.Name}\n{e.StackTrace}");
+				Logger.Debug($"Problem updating picturebox {0}\n{1}", pictureBox.Name, e);
 			}
 		}
 
@@ -111,7 +111,7 @@ namespace InventoryKamera
 			}
 			catch (Exception e)
 			{
-				Debug.WriteLine($"Problem updating textbox {textBox.Name}\n{e.StackTrace}");
+				Logger.Debug($"Problem updating picturebox {0}\n{1}", textBox.Name, e);
 			}
 		}
 
@@ -128,7 +128,8 @@ namespace InventoryKamera
 			}
 			catch (Exception e)
 			{
-				Debug.WriteLine($"Problem updating label {label.Name}\n{e.StackTrace}");
+				Logger.Debug($"Problem updating picturebox {0}\n{1}", label.Name, e);
+
 			}
 		}
 

--- a/InventoryKamera/ui/main/MainForm.Designer.cs
+++ b/InventoryKamera/ui/main/MainForm.Designer.cs
@@ -547,18 +547,18 @@
             this.FastScannerDelay_Label.Name = "FastScannerDelay_Label";
             this.FastScannerDelay_Label.Size = new System.Drawing.Size(20, 9);
             this.FastScannerDelay_Label.TabIndex = 74;
-            this.FastScannerDelay_Label.Text = "0ms";
+            this.FastScannerDelay_Label.Text = "Fast";
             // 
             // MidScannerDelay_Label
             // 
             this.MidScannerDelay_Label.AutoSize = true;
             this.MidScannerDelay_Label.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.MidScannerDelay_Label.Location = new System.Drawing.Point(63, 261);
+            this.MidScannerDelay_Label.Location = new System.Drawing.Point(60, 261);
             this.MidScannerDelay_Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.MidScannerDelay_Label.Name = "MidScannerDelay_Label";
-            this.MidScannerDelay_Label.Size = new System.Drawing.Size(24, 9);
+            this.MidScannerDelay_Label.Size = new System.Drawing.Size(29, 9);
             this.MidScannerDelay_Label.TabIndex = 75;
-            this.MidScannerDelay_Label.Text = "50ms";
+            this.MidScannerDelay_Label.Text = "Slower";
             // 
             // SlowScannerDelay_Label
             // 
@@ -567,9 +567,9 @@
             this.SlowScannerDelay_Label.Location = new System.Drawing.Point(108, 261);
             this.SlowScannerDelay_Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.SlowScannerDelay_Label.Name = "SlowScannerDelay_Label";
-            this.SlowScannerDelay_Label.Size = new System.Drawing.Size(28, 9);
+            this.SlowScannerDelay_Label.Size = new System.Drawing.Size(22, 9);
             this.SlowScannerDelay_Label.TabIndex = 76;
-            this.SlowScannerDelay_Label.Text = "100ms";
+            this.SlowScannerDelay_Label.Text = "Slow";
             // 
             // FileSelectButton
             // 

--- a/InventoryKamera/ui/main/MainForm.cs
+++ b/InventoryKamera/ui/main/MainForm.cs
@@ -69,7 +69,7 @@ namespace InventoryKamera
 					return 1;
 
 				case 2:
-					return 2;
+					return 1.5;
 
 				default:
 					return 1;

--- a/InventoryKamera/ui/main/MainForm.cs
+++ b/InventoryKamera/ui/main/MainForm.cs
@@ -368,11 +368,13 @@ namespace InventoryKamera
 				case "InventoryKey":
 					Navigation.inventoryKey = (VirtualKeyCode)e.KeyCode;
 					Logger.Debug("Inv key set to: {key}", Navigation.inventoryKey);
+					Properties.Settings.Default.InventoryKey = e.KeyValue;
 					break;
 
 				case "CharacterKey":
 					Navigation.characterKey = (VirtualKeyCode)e.KeyCode;
 					Logger.Debug("Char key set to: {key}", Navigation.characterKey);
+					Properties.Settings.Default.CharacterKey = e.KeyValue;
 					break;
 
 				default:

--- a/InventoryKamera/ui/main/MainForm.cs
+++ b/InventoryKamera/ui/main/MainForm.cs
@@ -23,7 +23,7 @@ namespace InventoryKamera
 		private static Thread scannerThread;
 		private static InventoryKamera data = new InventoryKamera();
 
-		private int Delay;
+        private int Delay;
 
 		private bool running = false;
 
@@ -58,21 +58,21 @@ namespace InventoryKamera
 			Logger.Info("MainForm initialization complete");
 		}
 
-		private int ScannerDelayValue(int value)
+		private double ScannerDelayValue(int value)
 		{
 			switch (value)
 			{
 				case 0:
-					return 0;
+					return 0.5;
 
 				case 1:
-					return 50;
+					return 1;
 
 				case 2:
-					return 100;
+					return 2;
 
 				default:
-					return 100;
+					return 1;
 			}
 		}
 
@@ -258,10 +258,9 @@ namespace InventoryKamera
 					{
 						ResetUI();
 						running = false;
-						Logger.Info("Scanner stopped");
                         ManualExportButton.Invoke((MethodInvoker)delegate 
 						{
-							ManualExportButton.Enabled = data.Inventory.Size > 0;
+							ManualExportButton.Enabled = data.HasData;
 						});
 					}
 				})


### PR DESCRIPTION
Fixed:

- Tartaglia's passive adding one more level to all characters basic attacks if he is in the on-field party
- Mora scanning should be more accurate now
- Material quantity scanning should be more accurate now
- Weapon/Artifact scrolling problems. Now about about a quarter second slower per page of items. It is what it is.
- Duplicate character scanning
- Artifact main stat bonuses being incorrectly labeled as flat instead of percentages
- Weapon/Artifact rarities should be more accurate now
- Not being able to export a scan with only characters
- Character keys not being saved if they were changed

New:
- Speeds updated to slow, normal, and fast. 
- Debug logging file alongside regular log file
- Improved artifact scan times for scans when artifact level filter is set to at least 1