### PR TITLE
Bug Fixes and Improvements

### DIFF
--- a/InventoryKamera/Properties/AssemblyInfo.cs
+++ b/InventoryKamera/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.6.0")]
-[assembly: AssemblyFileVersion("1.2.6.0")]
+[assembly: AssemblyVersion("1.2.7.0")]
+[assembly: AssemblyFileVersion("1.2.7.0")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/InventoryKamera/data/DatabaseManager.cs
+++ b/InventoryKamera/data/DatabaseManager.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -14,7 +13,7 @@ using Newtonsoft.Json.Linq;
 
 namespace InventoryKamera
 {
-	public class DatabaseManager
+    public class DatabaseManager
 	{
 		private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 		private string _listdir = @".\inventorylists\";
@@ -815,6 +814,7 @@ namespace InventoryKamera
 			string json = "";
 			using (WebClient client = new WebClient())
 			{
+				client.Encoding = System.Text.Encoding.UTF8;
 				json = client.DownloadString(url);
 			}
 			return json;

--- a/InventoryKamera/scraping/ArtifactScraper.cs
+++ b/InventoryKamera/scraping/ArtifactScraper.cs
@@ -238,10 +238,10 @@ namespace InventoryKamera
 			using (BlobCounter blobCounter = new BlobCounter
 			{
 				FilterBlobs = true,
-				MinHeight = card.Height - 15,
-				MaxHeight = card.Height + 15,
-				MinWidth = card.Width - 15,
-				MaxWidth = card.Width + 15,
+				MinHeight = card.Height - ((int)(card.Height * 0.2)),
+				MaxHeight = card.Height + ((int)(card.Height * 0.2)),
+				MinWidth = card.Width - ((int)(card.Width * 0.2)),
+				MaxWidth = card.Width + ((int)(card.Width * 0.2)),
 			})
 			{
 				// Image pre-processing
@@ -465,8 +465,11 @@ namespace InventoryKamera
 
             if (GetRarity(name) < Properties.Settings.Default.MinimumArtifactRarity)
 			{
-				artifactImages.ForEach(i => i.Dispose());
-				StopScanning = true;
+				if (ScanArtifactLevel(level) < Properties.Settings.Default.MinimumArtifactLevel)
+				{ 
+					artifactImages.ForEach(i => i.Dispose());
+					StopScanning = true;
+				}
 			}
 			else // Send images to Worker Queue
 				InventoryKamera.workerQueue.Enqueue(new OCRImageCollection(artifactImages, "artifact", id));

--- a/InventoryKamera/scraping/CharacterScraper.cs
+++ b/InventoryKamera/scraping/CharacterScraper.cs
@@ -56,15 +56,15 @@ namespace InventoryKamera
 			}
 
             // Childe passive buff fix
-            foreach (var character in Characters.Take(4))
+            foreach (var character in Characters)
             {
-				if (character.Name.ToLower() == "tartaglia")
+				if (character.Name.ToLower() == "tartaglia" && character.Ascension >= 4)
                 {
 					for (int i = 0; i < Characters.Count; i++)
 					{
 						Characters[i].Talents["auto"] -= 1;
 					}
-					Logger.Info("Tartaglia in on-field party, applied auto attack fix.");
+					Logger.Info("Ascension 4+ Tartaglia found, applied auto attack fix.");
 					break;
 				}
             }
@@ -104,8 +104,8 @@ namespace InventoryKamera
 				character.Level = level;
 				character.Ascended = ascended;
 
-				Logger.Info("{name:l} Level: {level:l}", character.Name, character.Level);
-				Logger.Info("{name:l} Ascended: {ascended:l}", character.Name, character.Ascended);
+				Logger.Info("{0} Level: {1}", character.Name, character.Level);
+				Logger.Info("{0} Ascended: {1}", character.Name, character.Ascended);
 
 				// Scan Experience
 				//experience = ScanExperience();
@@ -114,13 +114,13 @@ namespace InventoryKamera
 				// Scan Constellation
 				Navigation.SelectCharacterConstellation();
 				character.Constellation = ScanConstellations();
-				Logger.Info("{name:l} Constellation: {constellation:l}", character.Name, character.Constellation);
+				Logger.Info("{0} Constellation: {0}", character.Name, character.Constellation);
 				Navigation.SystemWait(Navigation.Speed.Normal);
 
 				// Scan Talents
 				Navigation.SelectCharacterTalents();
 				character.Talents = ScanTalents(name);
-				Logger.Info("{name:l} Talents: {talents:l}", character.Name, character.Talents);
+				Logger.Info("{0} Talents: {1}", character.Name, character.Talents);
 				Navigation.SystemWait(Navigation.Speed.Normal);
 
 				// Scale down talents due to constellations

--- a/InventoryKamera/scraping/MaterialScraper.cs
+++ b/InventoryKamera/scraping/MaterialScraper.cs
@@ -284,11 +284,19 @@ namespace InventoryKamera
 
 		public static (List<Rectangle> rectangles, int cols, int rows) ProcessScreenshot(Bitmap screenshot)
 		{
+			// Size of an item card is the same in 16:10 and 16:9. Also accounts for character icon and resolution size.
+			double base_aspect_width = 1280.0;
+			double base_aspect_height = 720.0;
 			var card = new RECT(
 				Left: 0,
 				Top: 0,
-				Right: (int)(85 / 1280.0 * screenshot.Width),
-				Bottom: (int)(100 / 720.0 * screenshot.Height));
+				Right: (int)(85 / base_aspect_width * screenshot.Width),
+				Bottom: (int)(105 / base_aspect_height * screenshot.Height));
+
+			if (Navigation.GetAspectRatio() == new Size(8, 5))
+			{
+				base_aspect_height = 800.0;
+			}
 
 			// Filter for relative size of items in inventory, give or take a few pixels
 			using (BlobCounter blobCounter = new BlobCounter
@@ -303,7 +311,7 @@ namespace InventoryKamera
 				// Image pre-processing
 				screenshot = new KirschEdgeDetector().Apply(screenshot); // Algorithm to find edges. Really good but can take ~1s
 				screenshot = new Grayscale(0.2125, 0.7154, 0.0721).Apply(screenshot);
-				screenshot = new Threshold(100).Apply(screenshot); // Convert to black and white only based on pixel intensity
+				screenshot = new Threshold(100).Apply(screenshot); // Convert to black and white only based on pixel intensity			
 
 				blobCounter.ProcessImage(screenshot);
 				// Note: Processing won't always detect all item rectangles on screen. Since the
@@ -311,7 +319,7 @@ namespace InventoryKamera
 
 				if (blobCounter.ObjectsCount < 7)
 				{
-					throw new Exception();
+					throw new Exception("Insufficient items found in artifact inventory");
 				}
 
 				// Don't save overlapping blobs
@@ -336,8 +344,8 @@ namespace InventoryKamera
 					}
 					if (add)
 					{
-						minWidth = Math.Max(minWidth, rect.Width);
-						minHeight = Math.Max(minHeight, rect.Height);
+						minWidth = Math.Min(minWidth, rect.Width);
+						minHeight = Math.Min(minHeight, rect.Height);
 						rectangles.Add(rect);
 					}
 				}
@@ -353,7 +361,7 @@ namespace InventoryKamera
 					foreach (var x in colCoords)
 					{
 						var xC = item.Center().X;
-						if (x - 50 / 1280.0 * screenshot.Width <= xC && xC <= x + 50 / 1280.0 * screenshot.Width)
+						if (x - 75 / base_aspect_width * screenshot.Width <= xC && xC <= x + 75 / base_aspect_width * screenshot.Width)
 						{
 							addX = false;
 							break;
@@ -362,7 +370,7 @@ namespace InventoryKamera
 					foreach (var y in rowCoords)
 					{
 						var yC = item.Center().Y;
-						if (y - 50 / 720.0 * screenshot.Height <= yC && yC <= y + 50 / 720.0 * screenshot.Height)
+						if (y - 100 / base_aspect_height * screenshot.Height <= yC && yC <= y + 100 / base_aspect_height * screenshot.Height)
 						{
 							addY = false;
 							break;
@@ -389,10 +397,11 @@ namespace InventoryKamera
 
 				foreach (var row in rowCoords)
 				{
+
 					foreach (var col in colCoords)
 					{
-						int x = (int)( col - (minWidth * .5) );
-						int y = (int)( row - (minHeight * .5) );
+						int x = (int)(col - (minWidth * .5));
+						int y = (int)(row - (minHeight * .5));
 
 						rectangles.Add(new Rectangle(x, y, minWidth, minHeight));
 					}

--- a/InventoryKamera/scraping/MaterialScraper.cs
+++ b/InventoryKamera/scraping/MaterialScraper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -295,10 +294,10 @@ namespace InventoryKamera
 			using (BlobCounter blobCounter = new BlobCounter
 			{
 				FilterBlobs = true,
-				MinHeight = card.Height - 15,
-				MaxHeight = card.Height + 15,
-				MinWidth = card.Width - 15,
-				MaxWidth = card.Width + 15,
+				MinHeight = card.Height - ((int)(card.Height * 0.2)),
+				MaxHeight = card.Height + ((int)(card.Height * 0.2)),
+				MinWidth = card.Width - ((int)(card.Width * 0.2)),
+				MaxWidth = card.Width + ((int)(card.Width * 0.2)),
 			})
 			{
 				// Image pre-processing

--- a/InventoryKamera/scraping/Scraper.cs
+++ b/InventoryKamera/scraping/Scraper.cs
@@ -603,8 +603,6 @@ namespace InventoryKamera
 			var c2 = Color.FromArgb((int)color.Red.Mean, (int)color.Green.Mean, (int)color.Blue.Mean);
 			var diff = colors.Select(x => new { Value = x, Diff = GetColorDifference(x, c2) }).ToList();
 
-			Logger.Debug("Average Color: {0}", c2);
-
 			foreach (var c in colors)
             {
                 if (CompareColors(c, c2)) return c;

--- a/InventoryKamera/scraping/WeaponScraper.cs
+++ b/InventoryKamera/scraping/WeaponScraper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -184,10 +183,10 @@ namespace InventoryKamera
 			using (BlobCounter blobCounter = new BlobCounter
 			{
 				FilterBlobs = true,
-				MinHeight = card.Height - 15,
-				MaxHeight = card.Height + 15,
-				MinWidth = card.Width - 15,
-				MaxWidth = card.Width + 15,
+				MinHeight = card.Height - ((int)(card.Height * 0.2)),
+				MaxHeight = card.Height + ((int)(card.Height * 0.2)),
+				MinWidth = card.Width - ((int)(card.Width * 0.2)),
+				MaxWidth = card.Width + ((int)(card.Width * 0.2)),
 			})
 			{
 				// Image pre-processing
@@ -198,7 +197,6 @@ namespace InventoryKamera
 				blobCounter.ProcessImage(screenshot);
 				// Note: Processing won't always detect all item rectangles on screen. Since the
 				// background isn't a solid color it's a bit trickier to filter out.
-
 
 				if (blobCounter.ObjectsCount < 7)
 				{
@@ -404,9 +402,13 @@ namespace InventoryKamera
 
             if (GetRarity(name) < Properties.Settings.Default.MinimumWeaponRarity)
 			{
-				weaponImages.ForEach(i => i.Dispose());
-				StopScanning = true;
-				return;
+				bool a = false;
+				if (ScanLevel(level, ref a) < Properties.Settings.Default.MinimumWeaponLevel)
+				{
+					weaponImages.ForEach(i => i.Dispose());
+					StopScanning = true;
+					return;
+				}
 			}
 			else // Send images to worker queue
 				InventoryKamera.workerQueue.Enqueue(new OCRImageCollection(weaponImages, "weapon", id));

--- a/InventoryKamera/ui/main/MainForm.Designer.cs
+++ b/InventoryKamera/ui/main/MainForm.Designer.cs
@@ -648,7 +648,7 @@
             this.inventoryToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.inventoryToolStripTextBox});
             this.inventoryToolStripMenuItem.Name = "inventoryToolStripMenuItem";
-            this.inventoryToolStripMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.inventoryToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.inventoryToolStripMenuItem.Text = "Inventory Key";
             // 
             // inventoryToolStripTextBox
@@ -667,7 +667,7 @@
             this.characterScreenToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.characterToolStripTextBox});
             this.characterScreenToolStripMenuItem.Name = "characterScreenToolStripMenuItem";
-            this.characterScreenToolStripMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.characterScreenToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.characterScreenToolStripMenuItem.Text = "Character Screen Key";
             // 
             // characterToolStripTextBox
@@ -684,14 +684,14 @@
             // DatabaseUpdateMenuItem
             // 
             this.DatabaseUpdateMenuItem.Name = "DatabaseUpdateMenuItem";
-            this.DatabaseUpdateMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.DatabaseUpdateMenuItem.Size = new System.Drawing.Size(191, 22);
             this.DatabaseUpdateMenuItem.Text = "Update Lookup Tables";
             this.DatabaseUpdateMenuItem.Click += new System.EventHandler(this.DatabaseUpdateMenuItem_Click);
             // 
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(190, 22);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(191, 22);
             this.toolStripMenuItem1.Text = "Open Export Folder";
             this.toolStripMenuItem1.Click += new System.EventHandler(this.ExportFolderMenuItem_Click);
             // 

--- a/InventoryKamera/ui/main/MainForm.cs
+++ b/InventoryKamera/ui/main/MainForm.cs
@@ -125,6 +125,7 @@ namespace InventoryKamera
 				}
 				catch (Exception) { }
 				Properties.Settings.Default.UpgradeNeeded = false;
+				Properties.Settings.Default.Save();
 			}
 
 			UpdateKeyTextBoxes();


### PR DESCRIPTION
Fixed updater failing to decode data from URL
Fixed rows of items being skipped during scan
Fixed weapon/artifact scan to stop when level and rarity filters met.
Fixed Tartaglia raising auto attacks when not in party.
Adjusted finding items in inventory to click.
Added logging weapon/artifact logging as scanned