### PR TITLE
Added JSON settings provider

### DIFF
--- a/InventoryKamera/InventoryKamera.csproj
+++ b/InventoryKamera/InventoryKamera.csproj
@@ -161,6 +161,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="game\Artifact.cs" />
+    <Compile Include="Properties\JsonUserSettingsProvider.cs" />
     <Compile Include="scraping\ArtifactScraper.cs" />
     <Compile Include="game\Character.cs" />
     <Compile Include="data\DatabaseManager.cs" />

--- a/InventoryKamera/Properties/JsonUserSettingsProvider.cs
+++ b/InventoryKamera/Properties/JsonUserSettingsProvider.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Specialized;
+using System.Configuration;
+using System.IO;
+using System.Windows.Forms;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace InventoryKamera.Properties
+{
+    /// <summary>
+    /// Simple JSON SettingsProvider with only support of <see cref="SettingsSerializeAs.String"/> serialized properties
+    /// with <see cref="UserScopedSettingAttribute"/>
+    /// </summary>
+    /// <exception cref="ConfigurationErrorsException"></exception>
+    public class JsonUserSettingsProvider : SettingsProvider
+    {
+        public static string SettingsFileName => "settings.json";
+
+        public static string SettingsDirectory => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            Path.GetFileNameWithoutExtension(Application.ExecutablePath));
+
+        private static string SettingsFile => Path.Combine(SettingsDirectory, SettingsFileName);
+
+        public override string ApplicationName
+        {
+            get => Path.GetFileNameWithoutExtension(Application.ExecutablePath);
+            set { }
+        }
+
+        public override string Name => "JsonUserSettingsProvider";
+
+        public override void Initialize(string name, NameValueCollection config)
+        {
+            base.Initialize(Name, config);
+        }
+
+        public override SettingsPropertyValueCollection GetPropertyValues(SettingsContext context,
+            SettingsPropertyCollection properties)
+        {
+            var values = new SettingsPropertyValueCollection();
+
+            var settingsJson = new JObject();
+
+            Directory.CreateDirectory(SettingsDirectory);
+
+            if (File.Exists(SettingsFile))
+            {
+                try
+                {
+                    settingsJson = JObject.Parse(File.ReadAllText(SettingsFile));
+                }
+                catch (JsonReaderException exception)
+                {
+                    // Using default setting cause file isn't valid JSON
+                }
+            }
+
+            foreach (SettingsProperty property in properties)
+            {
+                bool isUserSetting =
+                    property.Attributes[typeof(UserScopedSettingAttribute)] is UserScopedSettingAttribute;
+                if (!isUserSetting)
+                {
+                    throw new ConfigurationErrorsException("Application scoped properties aren't supported");
+                }
+
+                string propertyName = property.Name;
+                var value = new SettingsPropertyValue(property) {IsDirty = false};
+
+                JToken settingToken = settingsJson[propertyName];
+                if (settingToken != null)
+                {
+                    if (property.SerializeAs != SettingsSerializeAs.String)
+                    {
+                        throw new ConfigurationErrorsException(
+                            "Propeties with serialization otherwise String aren't supported");
+                    }
+
+                    value.SerializedValue = settingToken.ToString();
+                }
+                else
+                {
+                    value.SerializedValue = property.DefaultValue;
+                }
+
+                values.Add(value);
+            }
+
+            return values;
+        }
+
+        public override void SetPropertyValues(SettingsContext context, SettingsPropertyValueCollection values)
+        {
+            var settingsJson = new JObject();
+
+            foreach (SettingsPropertyValue value in values)
+            {
+                bool isUserSetting =
+                    value.Property.Attributes[typeof(UserScopedSettingAttribute)] is UserScopedSettingAttribute;
+
+                if (!isUserSetting)
+                {
+                    throw new ConfigurationErrorsException("Application scoped properties aren't supported");
+                }
+
+                if (value.Property.SerializeAs != SettingsSerializeAs.String)
+                {
+                    throw new ConfigurationErrorsException(
+                        "Propeties with serialization otherwise String aren't supported");
+                }
+
+                settingsJson[value.Name] = new JValue((string) value.SerializedValue);
+            }
+
+            File.WriteAllText(SettingsFile, JsonConvert.SerializeObject(settingsJson, Formatting.Indented));
+        }
+    }
+}

--- a/InventoryKamera/Properties/Settings.Designer.cs
+++ b/InventoryKamera/Properties/Settings.Designer.cs
@@ -8,11 +8,14 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
+using System.Configuration;
+
 namespace InventoryKamera.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
+    [SettingsProvider(typeof(JsonUserSettingsProvider))]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));


### PR DESCRIPTION
For issue #301. 
Stores settings in JSON file, support only string serialized and user scoped properties which isn't problem as all of it already satisfy these constraints. Keep in mind if it will not satisfy in future then SettingsProviderAttribute can be applied directly to properties. Also there's no backward compatibility with previous xml configuration. Due to way of settings read it's support upgrade, undiscovered properties will be set with default value.
Location of file is %AppData%/Local/InventoryKamera/settings.json
Suggestions and improvements are welcome.