### PR TITLE
Fixed characters scan infinite loop

### DIFF
--- a/InventoryKamera/scraping/CharacterScraper.cs
+++ b/InventoryKamera/scraping/CharacterScraper.cs
@@ -24,7 +24,8 @@ namespace InventoryKamera
 			while (true)
 			{
 				var character = ScanCharacter(first);
-				if (Characters.Count > 0 && character.NameGOOD == Characters.ElementAt(0).NameGOOD) break;
+				if (Characters.Count > 0 && (character.NameGOOD == Characters.ElementAt(0).NameGOOD 
+                                             || character.NameGOOD == "Traveler" && character.NameGOOD + character.Element == Characters.ElementAt(0).NameGOOD)) break;
 				if (character.IsValid())
 				{
 					if (!scanned.Contains(character.NameGOOD))
@@ -105,7 +106,7 @@ namespace InventoryKamera
 			character.Element = element;
 
 			// Check if character was first scanned
-			if (character.NameGOOD != firstCharacter)
+			if (character.NameGOOD == "Traveler" && character.NameGOOD + character.Element != firstCharacter || character.NameGOOD != "Traveler" && character.NameGOOD != firstCharacter)
 			{
 				bool ascended = false;
 				// Scan Level and ascension

--- a/InventoryKamera/scraping/CharacterScraper.cs
+++ b/InventoryKamera/scraping/CharacterScraper.cs
@@ -141,11 +141,11 @@ namespace InventoryKamera
 				// Scale down talents due to constellations
 				if (character.Constellation >= 3)
 				{
-					if (Scraper.Characters.ContainsKey(name.ToLower()))
+					if (Scraper.Characters.ContainsKey(character.NameInternal))
 					{
 						string talentLeveledAtConst3 = character.NameGOOD == "Traveler"
-                            ? (string)Scraper.Characters[name.ToLower()]["ConstellationOrder"][character.Element.ToLower()][0]
-                            : (string)Scraper.Characters[name.ToLower()]["ConstellationOrder"][0];
+                            ? (string)Scraper.Characters[character.NameInternal]["ConstellationOrder"][character.Element.ToLower()][0]
+                            : (string)Scraper.Characters[character.NameInternal]["ConstellationOrder"][0];
 
                         // Scale down talents
                         if (character.Constellation >= 5)


### PR DESCRIPTION
Fixes #429, #422 
That's happens when there's Traveler in first slot.

Into characters list adds with element postfix ("TravelerAnemo", "TravelerGeo" etc). But when scanned NameGood is "Traveler" and internal is username. So loop break condition never works for it because "Traveler" not equals "TravelerAnemo" and same for other elements.
It's require more deep understanding of whole system to provide better solution. But at least that fix works.