### PR TITLE
Fix lookup table update for traveler

### DIFF
--- a/InventoryKamera/data/DatabaseManager.cs
+++ b/InventoryKamera/data/DatabaseManager.cs
@@ -411,7 +411,7 @@ namespace InventoryKamera
                                 var travelerDoc = new HtmlDocument();
                                 travelerDoc.LoadHtml(travelerHTML);
 
-                                var talents = travelerDoc.DocumentNode.SelectSingleNode("//div[contains(@class, 'talent-table')]")
+                                var talents = travelerDoc.DocumentNode.SelectSingleNode("//table[contains(@class, 'talent-table')]")
                                                     .Descendants("tr")
                                                     .Where(tr => tr.InnerText.Contains("Normal Attack") || tr.InnerText.Contains("Elemental Skill") || tr.InnerText.Contains("Elemental Burst"))
                                                     .Where(tr => tr.Elements("td").Count() == 3)


### PR DESCRIPTION
A page format was changed on the wiki, breaking the update of the characters lookup page. It seems that the app expected a div with a talent-table class, but the current version of the page has that class on a table element.

![image](https://github.com/Andrewthe13th/Inventory_Kamera/assets/2313294/29a19d49-dcbb-45d3-8fe4-c4bf849cfe4e)

I replaced the div selector with the table selector, and ran the lookup table feature with a local debug build to confirm that it is working after the change. Haven't ran any of the actual scans, but the traveler part of the characters.json file looks more or less correct I think.
```
  "traveler": {
    "GOOD": "Traveler",
    "ConstellationName": [
      "Viator",
      "Viatrix"
    ],
    "ConstellationOrder": {
      "dendro": [
        "skill",
        "burst"
      ],
      "electro": [
        "skill",
        "burst"
      ],
      "anemo": [
        "skill",
        "burst"
      ],
      "geo": [
        "skill",
        "burst"
      ]
    },
    "WeaponType": 0
  },
  ```