### PR TITLE
Correct equipped bitmap dimensions

### DIFF
--- a/InventoryKamera/scraping/InventoryScraper.cs
+++ b/InventoryKamera/scraping/InventoryScraper.cs
@@ -504,8 +504,8 @@ namespace InventoryKamera
         {
             return GenshinProcesor.CopyBitmap(card,
                 new Rectangle(
-                    x: 0,
-                    y: (int)(double)(card.Height * (double)(Navigation.IsNormal ? 0.927 : 0.936)),
+                    x: (int)(card.Width * 0.15),
+                    y: (int)(double)(card.Height * (double)(Navigation.IsNormal ? 0.938 : 0.943)),
                     width: card.Width,
                     height: card.Height));
         }


### PR DESCRIPTION
Correct the dimensions of equipped bitmaps so they don't include the character icon and the text above.

Before:
![image](https://github.com/Andrewthe13th/Inventory_Kamera/assets/42590338/7a79ea3a-e598-4c3f-9c74-58e2a16b8f77)

After:
![equipped](https://github.com/Andrewthe13th/Inventory_Kamera/assets/42590338/6b7d00af-5352-4201-90ec-79472ded90cd)


Fixes #466