### PR TITLE
fix bug for lock status always set to false

### DIFF
--- a/InventoryKamera/data/InventoryKamera.cs
+++ b/InventoryKamera/data/InventoryKamera.cs
@@ -384,6 +384,8 @@ namespace InventoryKamera
 								imageCollection.Bitmaps[4].Save(artifactPath + "substats/substats.png");
 								Directory.CreateDirectory(artifactPath + "equipped");
 								imageCollection.Bitmaps[5].Save(artifactPath + "equipped/equipped.png");
+								Directory.CreateDirectory(artifactPath + "locked");
+								imageCollection.Bitmaps[6].Save(artifactPath + "locked/locked.png");
 
 								imageCollection.Bitmaps.Last().Save(artifactPath + "card.png");
 

--- a/InventoryKamera/scraping/ArtifactScraper.cs
+++ b/InventoryKamera/scraping/ArtifactScraper.cs
@@ -253,7 +253,7 @@ namespace InventoryKamera
 
 				// Check for lock color
 				Color lockedColor = Color.FromArgb(255, 70, 80, 100); // Dark area around red lock
-				Color lockStatus = bm[a_lock].GetPixel(5, 5);
+				Color lockStatus = bm[a_lock].GetPixel(10, 10);
 				_lock = GenshinProcesor.CompareColors(lockedColor, lockStatus);
 
 				// Improved Scanning using multi threading


### PR DESCRIPTION
The black color pixel is located at 10,10 not 5,5 for current version of genshin impact.