### PR TITLE
Update repoBaseURL to use updated remote trunk branch

### DIFF
--- a/InventoryKamera/data/DatabaseManager.cs
+++ b/InventoryKamera/data/DatabaseManager.cs
@@ -38,7 +38,7 @@ namespace InventoryKamera
         private readonly string NewVersion = "version.txt";
 
         private const string commitsAPIURL = "https://gitlab.com/api/v4/projects/53209414/repository/commits";
-        private const string repoBaseURL = "https://gitlab.com/Dimbreath/AnimeGameData/-/raw/master/";
+        private const string repoBaseURL = "https://gitlab.com/Dimbreath/AnimeGameData/-/raw/main/";
         private const string TextMapEnURL = repoBaseURL + "TextMap/TextMapEN.json";
         private const string CharactersURL = repoBaseURL + "ExcelBinOutput/AvatarExcelConfigData.json";
         private const string ConstellationsURL = repoBaseURL + "ExcelBinOutput/FetterInfoExcelConfigData.json";


### PR DESCRIPTION
The game data repo renamed its trunk branch from `master` to `main`, so the hardcorded URL needs to be updated for pulling data from it to work. This should fix issue #488.