### PR TITLE
Revert ArtifactScraper.cs changes

### DIFF
--- a/InventoryKamera/scraping/ArtifactScraper.cs
+++ b/InventoryKamera/scraping/ArtifactScraper.cs
@@ -447,7 +447,7 @@ namespace InventoryKamera
 				if (line.Any(char.IsDigit))
 				{
 					SubStat substat = new SubStat();
-					Regex re = new Regex(@"^(.*?)(\d+)");
+					Regex re = new Regex(@"([\w]+\W*)(\d+.*\d+)");
 					var result = re.Match(line);
 					var stat = Regex.Replace(result.Groups[1].Value, @"[^\w]", string.Empty);
 					var value = result.Groups[2].Value;
@@ -465,6 +465,9 @@ namespace InventoryKamera
 						Logger.Debug("Failed to parse stat value from: {1}", line);
 						substat.value = -1;
 					}
+
+					// Need to retain the decimal place for percent boosts
+					if (substat.stat.Contains("_")) substat.value /= 10;
 
 					if (string.IsNullOrWhiteSpace(substat.stat))
 					{


### PR DESCRIPTION
Related to #503 

- Reverts change to fix decimal parsing on percentages

Example output files (tested fix by running in Debug mode in Rider, and scanning a subset of my artifacts):

- [before_fix_GOOD.json](https://github.com/Andrewthe13th/Inventory_Kamera/files/14152555/before_fix_GOOD.json)
- [after_fix_GOOD.json](https://github.com/Andrewthe13th/Inventory_Kamera/files/14152573/after_fix_GOOD.json)

Diff of results (`diff before_fix_GOOD.json after_fix_GOOD.json > diff.patch`)

- [diff.patch](https://github.com/Andrewthe13th/Inventory_Kamera/files/14152576/diff.patch)

Also confirmed that GenshinOptimizer does not show the stats as invalid after uploading post-fix.


I'm not familiar with C# or the intent of the original change, so feel free to push back or give feedback.