### PR TITLE
Fixed 5.2 artifact inventory UI change bug

### DIFF
--- a/InventoryKamera/scraping/ArtifactScraper.cs
+++ b/InventoryKamera/scraping/ArtifactScraper.cs
@@ -133,7 +133,7 @@ namespace InventoryKamera
 						Navigation.Wait(1);
 					}
                     // Scroll back one to keep it from getting too crazy
-                    if (page % 3 == 0)
+                    if (page % 7 == 0)
                     {
 						Logger.Debug("Scrolled back one");
 						Navigation.sim.Mouse.VerticalScroll(1);

--- a/InventoryKamera/scraping/ArtifactScraper.cs
+++ b/InventoryKamera/scraping/ArtifactScraper.cs
@@ -133,7 +133,7 @@ namespace InventoryKamera
 						Navigation.Wait(1);
 					}
                     // Scroll back one to keep it from getting too crazy
-                    if (page % 7 == 0)
+                    if (page % 12 == 0)
                     {
 						Logger.Debug("Scrolled back one");
 						Navigation.sim.Mouse.VerticalScroll(1);

--- a/InventoryKamera/scraping/InventoryScraper.cs
+++ b/InventoryKamera/scraping/InventoryScraper.cs
@@ -410,11 +410,12 @@ namespace InventoryKamera
                     List<Rectangle> rectangles;
                     int cols, rows, itemCount, counter = 0;
                     double weight = 0;
+                    int itemPerPage = inventoryPage == InventoryPage.Artifacts ? 32 : 40;
                     do
                     {
                         (rectangles, cols, rows) = ProcessScreenshot(processedScreenshot, weight);
                         itemCount = rows * cols;
-                        if (itemCount != 32 && !acceptLess)
+                        if (itemCount != itemPerPage && !acceptLess)
                         {
                             Logger.Warn("Unable to locate full page of weapons with weight {0}", weight);
                             Logger.Warn("Detected {0} rows and {1} columns of items", rows, cols);
@@ -440,7 +441,7 @@ namespace InventoryKamera
                         weight = Math.Min(weight, 1);
                         rectangles = null;
                     }
-                    while (itemCount != 32 && weight < 1 && counter < 25);
+                    while (itemCount != itemPerPage && weight < 1 && counter < 25);
 
                     if (Properties.Settings.Default.LogScreenshots)
                     {
@@ -454,7 +455,7 @@ namespace InventoryKamera
 
                     if (rectangles == null)
                     {
-                        Logger.Warn("Could not find 32 items in inventory. Re-using previous item page.");
+                        Logger.Warn("Could not find {0} items in inventory. Re-using previous item page.", itemPerPage);
 
                         return prevRect == null ?
                             throw new ArgumentNullException("Could not find first page of items!") 

--- a/InventoryKamera/scraping/InventoryScraper.cs
+++ b/InventoryKamera/scraping/InventoryScraper.cs
@@ -386,7 +386,15 @@ namespace InventoryKamera
                 using (var brush = new SolidBrush(Color.Black))
                 {
                     // Fill Top region
-                    g.FillRectangle(brush, 0, 0, processedScreenshot.Width, (int)(processedScreenshot.Height * 0.09));
+                    switch (inventoryPage)
+                    {
+                        case InventoryPage.Artifacts:
+                            g.FillRectangle(brush, 0, 0, processedScreenshot.Width, (int)(processedScreenshot.Height * 0.143));
+                            break;
+                        default:
+                            g.FillRectangle(brush, 0, 0, processedScreenshot.Width, (int)(processedScreenshot.Height * 0.09));
+                            break;
+                    }
 
                     // Fill Left region
                     g.FillRectangle(brush, 0, 0, (int)(processedScreenshot.Width * 0.05), processedScreenshot.Height);
@@ -406,7 +414,7 @@ namespace InventoryKamera
                     {
                         (rectangles, cols, rows) = ProcessScreenshot(processedScreenshot, weight);
                         itemCount = rows * cols;
-                        if (itemCount != 40 && !acceptLess)
+                        if (itemCount != 32 && !acceptLess)
                         {
                             Logger.Warn("Unable to locate full page of weapons with weight {0}", weight);
                             Logger.Warn("Detected {0} rows and {1} columns of items", rows, cols);
@@ -425,14 +433,14 @@ namespace InventoryKamera
                         }
                         else break;
 
-                        if (itemCount <= 40)
+                        if (itemCount <= 32)
                             weight += 0.125;
                         else
                         { weight -= 0.095; ++counter; }
                         weight = Math.Min(weight, 1);
                         rectangles = null;
                     }
-                    while (itemCount != 40 && weight < 1 && counter < 25);
+                    while (itemCount != 32 && weight < 1 && counter < 25);
 
                     if (Properties.Settings.Default.LogScreenshots)
                     {
@@ -446,7 +454,7 @@ namespace InventoryKamera
 
                     if (rectangles == null)
                     {
-                        Logger.Warn("Could not find 40 items in inventory. Re-using previous item page.");
+                        Logger.Warn("Could not find 32 items in inventory. Re-using previous item page.");
 
                         return prevRect == null ?
                             throw new ArgumentNullException("Could not find first page of items!") 
@@ -516,7 +524,7 @@ namespace InventoryKamera
         {
             return GenshinProcesor.CopyBitmap(card,
                 new Rectangle(
-                    x: (int)(card.Width * 0.855),
+                    x: (int)(card.Width * 0.75),
                     y: (int)(card.Height * (Navigation.IsNormal ? 0.353 : 0.309)),
                     width: (int)(card.Width * 0.0955),
                     height: (int)(card.Height * (Navigation.IsNormal ? 0.055 : 0.0495))));


### PR DESCRIPTION
Version 5.2 update added a sort by obtained to the top of the artifact inventory which shifted the items down a bit, additionally added a favorite icon that moved the lock icon a bit to the left.

- increased size of top fill region
- reduced item count per page for artifacts
- moved lock bitmap to new location
- reduced frequency of page scrolling backtracking

additional note: the lock bitmap location is shared with weapons, but since the weapon lock was already bugged before any changes, Im gonna leave it at that.