### PR TITLE
Update character talent region for 16:10 aspect ratio

### DIFF
--- a/InventoryKamera/scraping/CharacterScraper.cs
+++ b/InventoryKamera/scraping/CharacterScraper.cs
@@ -451,10 +451,10 @@ namespace InventoryKamera
 			if (Navigation.GetAspectRatio() == new Size(8, 5)) yRef = 800.0;
 
 			Rectangle region =  new Rectangle(
-				x:		(int)((Navigation.IsNormal ? 0.0003 : 0) * Navigation.GetWidth() ),
-				y:		(int)((Navigation.IsNormal ? 0.1278 : 0) * Navigation.GetHeight() ),
-				width:	(int)((Navigation.IsNormal ? 0.2913 : 0) * Navigation.GetWidth() ),
-				height:	(int)((Navigation.IsNormal ? 0.0711 : 0) * Navigation.GetHeight() ));
+				x:		(int)((Navigation.IsNormal ? 0.0003 : 0.0004) * Navigation.GetWidth() ),
+				y:		(int)((Navigation.IsNormal ? 0.1278 : 0.1083) * Navigation.GetHeight() ),
+				width:	(int)((Navigation.IsNormal ? 0.2913 : 0.3000) * Navigation.GetWidth() ),
+				height:	(int)((Navigation.IsNormal ? 0.0711 : 0.0585) * Navigation.GetHeight() ));
 
 			for (int i = 0; i < 3; i++)
 			{


### PR DESCRIPTION
Rectangle region for 16:10 aspect ratio was missing relative %s

- Should address #520
- Tested with 1920x1200 and 1280x800 