### PR TITLE
Increase valid level range from 90 to 100

### DIFF
--- a/InventoryKamera/game/Character.cs
+++ b/InventoryKamera/game/Character.cs
@@ -100,7 +100,7 @@ namespace InventoryKamera
 
         public bool HasValidLevel()
         {
-            return 1 <= Level && Level <= 90;
+            return 1 <= Level && Level <= 100;
         }
 
         public bool HasValidElement()
@@ -158,7 +158,7 @@ namespace InventoryKamera
             {
                 return 5;
             }
-            else if (Level <= 90 || (Level == 90 && !Ascended))
+            else if (Level <= 100 || (Level == 100 && !Ascended))
             {
                 return 6;
             }


### PR DESCRIPTION
The 6.0 update allow characters to break ascention limit to level 100 using "Masterless Stella Fortuna". This should hopefully allow characters with levels higher than 90 to be recognized.